### PR TITLE
Integrate search, company, and campaigns pages

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,52 @@ export const api = {
   },
 };
 
+// Typed helpers for unified search and shipments
+export type CompanySummary = {
+  company_id: string;
+  company_name: string;
+  shipments_12m: number;
+  last_activity: string | null;
+  top_routes: string[];
+  top_carriers: string[];
+};
+
+export type CompanyShipment = {
+  date: string;
+  origin_country: string;
+  dest_country: string;
+  mode: 'AIR'|'OCEAN';
+  hs_code: string | null;
+  value_usd: number | null;
+  gross_weight_kg: number | null;
+  carrier: string | null;
+};
+
+export async function postSearchCompanies(body: {
+  origin_country?: string;
+  dest_country?: string;
+  mode?: 'ANY'|'AIR'|'OCEAN';
+  carrier?: string;
+  hs_codes?: string[];
+  date_start?: string;
+  date_end?: string;
+  limit: number;
+  offset: number;
+  company_id?: string;
+}, signal?: AbortSignal): Promise<{ data: CompanySummary[]; total: number }> {
+  return api.post<{ data: CompanySummary[]; total: number }>(
+    '/public/searchCompanies',
+    body,
+    { signal }
+  );
+}
+
+export async function getCompanyShipments(params: { company_id: string; limit?: number; offset?: number }, signal?: AbortSignal): Promise<{ data: CompanyShipment[]; total: number }> {
+  const { company_id, limit = 50, offset = 0 } = params;
+  const searchParams = new URLSearchParams({ company_id, limit: String(limit), offset: String(offset) });
+  return api.get<{ data: CompanyShipment[]; total: number }>(`/public/getCompanyShipments?${searchParams.toString()}`, { signal });
+}
+
 export async function getFilterOptions(_input: object = {}, signal?: AbortSignal) {
   return api.get('/public/getFilterOptions', { signal });
 }


### PR DESCRIPTION
Add typed API helpers and types for company search and shipments to support frontend UI wiring.

---
<a href="https://cursor.com/background-agent?bcId=bc-18826c3c-8993-4cc2-b766-d0bb0df5b882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18826c3c-8993-4cc2-b766-d0bb0df5b882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

