### PR TITLE
FE: route search to API Gateway + CSV array payloads

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,268 +1,57 @@
-// Backwards-compatible base for legacy helper functions that expect /public
-import { auth } from '@/auth/firebaseClient';
-const BASE = (() => {
-  const envAny = (import.meta as any)?.env || {};
-  const base = envAny.VITE_API_BASE || envAny.VITE_PROXY_BASE || "/api/public";
-  if (base.endsWith("/public")) return base;
-  if (base.endsWith("/public/")) return base.slice(0, -1);
-  if (base === "/api/public") return base;
-  return base.replace(/\/$/, "") + "/public";
-})();
-
-// New generic API client per spec (expects BASE_ORIGIN without /public)
-const BASE_ORIGIN: string = (() => {
-  const raw = (import.meta as any).env?.VITE_API_BASE || "";
-  if (!raw) return BASE.replace(/\/public$/, "");
-  return raw.replace(/\/public\/?$/, "");
-})();
-
-async function j<T>(p: Promise<Response>): Promise<T> {
-  const r = await p;
-  if (!r.ok) {
-    const text = await r.text().catch(() => String(r.status));
-    throw new Error(text || String(r.status));
-  }
-  return r.json() as Promise<T>;
-}
-
-export const api = {
-  async get<T>(path: string, init?: RequestInit) {
-    const url = `${BASE_ORIGIN}${path}`;
-    const token = await auth?.currentUser?.getIdToken?.().catch(() => null);
-    const headers = {
-      'accept': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(init?.headers || {}),
-    } as Record<string, string>;
-    return j<T>(fetch(url, { ...(init || {}), headers, credentials: 'omit', cache: 'no-store' }));
-  },
-  async post<T>(path: string, body: unknown, init?: RequestInit) {
-    const url = `${BASE_ORIGIN}${path}`;
-    const token = await auth?.currentUser?.getIdToken?.().catch(() => null);
-    const headers = {
-      'content-type': 'application/json',
-      'accept': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(init?.headers || {}),
-    } as Record<string, string>;
-    return j<T>(fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body ?? {}),
-      credentials: 'omit',
-      cache: 'no-store',
-      ...init,
-    }));
-  },
-};
-
-// Typed helpers for unified search and shipments
-export type CompanySearchItem = {
-  company_id: string | null;
-  company_name: string;
-  shipments: number;
-  lastShipmentDate: string | null;
-  modes?: string[];
-  hsTop?: Array<{ v: string; c: number }>;
-  originsTop?: Array<{ v: string; c: number }>;
-  destsTop?: Array<{ v: string; c: number }>;
-  carriersTop?: Array<{ v: string; c: number }>;
-};
-
-export type ShipmentRow = {
-  shipped_on: string;
-  mode: 'ocean'|'air';
-  origin: string;
-  destination: string;
-  carrier: string | null;
-  value_usd: string | number | null;
-  weight_kg: string | number | null;
-};
-
-// Company item + KPI extractor tolerant to snake/camel
-export type CompanyItem = {
-  company_id: string | null;
-  company_name: string;
-  shipments_12m?: number; shipments12m?: number; shipments?: number;
-  last_activity?: string | null; lastActivity?: string | null; lastShipmentDate?: string | null;
-  origins_top?: string[]; originsTop?: string[];
-  dests_top?: string[];   destsTop?: string[];
-  carriers_top?: string[]; carriersTop?: string[];
-};
-
-export function kpiFrom(item: CompanyItem) {
-  const shipments12m = Number(
-    item.shipments12m ?? item.shipments_12m ?? item.shipments ?? 0
-  );
-  const lastActivity = (item.lastActivity ?? item.last_activity ?? item.lastShipmentDate) || null;
-  const originsTop   = item.originsTop   ?? item.origins_top   ?? [];
-  const destsTop     = item.destsTop     ?? item.dests_top     ?? [];
-  const carriersTop  = item.carriersTop  ?? item.carriers_top  ?? [];
-  return { shipments12m, lastActivity, originsTop, destsTop, carriersTop };
-}
-
-// Public API base (robust across Vite/Next)
-const API_BASE: string = ((import.meta as any)?.env?.VITE_API_BASE || process.env.NEXT_PUBLIC_API_BASE || '').replace(/\/$/, '');
-
-// New: searchCompanies params (array-based payload)
-export type SearchCompaniesParams = {
-  q?: string | null;
-  mode?: 'AIR' | 'OCEAN' | '' | null;
-  origin?: string[];   // ISO2
-  dest?: string[];     // ISO2
-  hs?: string[];       // array of strings (digit-only recommended)
+export type SearchFilters = {
+  q?: string;
+  origin?: string[]; // ISO2 upper-case: ["CN","US"]
+  dest?: string[];
+  hs?: string[];
   limit?: number;
   offset?: number;
 };
 
-export async function searchCompanies(params: SearchCompaniesParams) {
-  const safeArray = (v?: string[]) => (Array.isArray(v) ? v : []);
-  const limit = Math.min(params?.limit ?? 50, 50);
-  const offset = params?.offset ?? 0;
-  const body = {
-    q: params?.q ?? null,
-    mode: params?.mode ?? null,
-    origin: safeArray(params?.origin),
-    dest: safeArray(params?.dest),
-    hs: safeArray(params?.hs),
-    limit,
-    offset,
-  } as const;
-
-  let res: Response;
-  try {
-    res = await fetch(`${API_BASE}/public/searchCompanies`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-  } catch (e) {
-    throw new Error(`network_error:${String(e)}`);
-  }
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`bad_status:${res.status}:${text.substring(0, 300)}`);
-  }
-
-  const json: any = await res.json().catch(() => ({}));
-  const total = Number(json?.total ?? 0);
-  const items = Array.isArray(json?.items) ? json.items : [];
-  return { total, items } as { total: number; items: CompanySearchItem[] };
-}
-
-export type SearchCompaniesBody = {
-  q?: string;
-  mode?: 'air'|'ocean';
-  hs?: string[];
-  origin?: string[];
-  dest?: string[];
-  carrier?: string[];
-  startDate?: string; // YYYY-MM-DD
-  endDate?: string;   // YYYY-MM-DD
-  limit: number;
-  offset: number;
-  company_id?: string;       // accepted for summary lookup
-  company_ids?: string[];    // accepted for summary lookup
+export type SearchCompanyRow = {
+  company_id: string;
+  name: string;
+  kpis: {
+    shipments_12m: number;
+    last_activity: string | { value: string };
+  };
 };
 
-export async function postSearchCompanies(body: SearchCompaniesBody, signal?: AbortSignal): Promise<{ total: number; items: CompanySearchItem[] }> {
-  return api.post<{ total: number; items: CompanySearchItem[] }>(
-    '/public/searchCompanies',
-    body,
-    { signal }
-  );
+export type SearchCompaniesResponse = {
+  meta: { total: number; page: number; page_size: number };
+  rows: SearchCompanyRow[];
+};
+
+const GW =
+  process.env.NEXT_PUBLIC_LIT_GATEWAY_BASE ??
+  "https://logistics-intel-gateway-2e68g4k3.uc.gateway.dev";
+
+function toCsv(a?: string[]): string {
+  return Array.isArray(a) && a.length > 0 ? a.join(",") : "";
 }
 
-export async function getCompanyShipments(params: { company_id: string; limit?: number; offset?: number }, signal?: AbortSignal): Promise<{ rows: ShipmentRow[]; total?: number }> {
-  const { company_id, limit = 50, offset = 0 } = params;
-  const searchParams = new URLSearchParams({ company_id, limit: String(limit), offset: String(offset) });
-  return api.get<{ rows: ShipmentRow[]; total?: number }>(`/public/getCompanyShipments?${searchParams.toString()}`, { signal });
+function buildPayload(f: SearchFilters) {
+  const limit = Math.max(1, Math.min(50, Number(f.limit ?? 24)));
+  const offset = Math.max(0, Number(f.offset ?? 0));
+  return {
+    q: (f.q ?? "").trim(),
+    origin: toCsv(f.origin),
+    dest: toCsv(f.dest),
+    hs: toCsv(f.hs),
+    limit,
+    offset,
+  };
 }
 
-export async function getFilterOptions(_input: object = {}, signal?: AbortSignal) {
-  return api.get('/public/getFilterOptions', { signal });
-}
-
-export type SearchCompaniesInput = { q?: string; mode?: "all"|"ocean"|"air"; filters?: Record<string, any>; dateRange?: { from?: string; to?: string }; pagination?: { limit?: number; offset?: number } };
-
-// Removed legacy searchCompanies helper that posted to /search (no longer used)
-
-// Widgets
-export async function calcTariff(input: { hsCode?: string; origin?: string; destination?: string; valueUsd?: number }, signal?: AbortSignal) {
-  const res = await fetch(`${BASE}/widgets/tariff/calc`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json' },
-    body: JSON.stringify(input || {}),
-    signal,
-  });
-  if (!res.ok) throw new Error(`calcTariff ${res.status}`);
-  return res.json();
-}
-
-export async function generateQuote(input: { companyId?: string|number; lanes: Array<{ origin: string; destination: string; mode: string }>; notes?: string }, signal?: AbortSignal) {
-  const res = await fetch(`${BASE}/widgets/quote/generate`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json' },
-    body: JSON.stringify(input || {}),
-    signal,
-  });
-  if (!res.ok) throw new Error(`generateQuote ${res.status}`);
-  return res.json();
-}
-
-// ------------------------ CRM / Enrich / Recall / Campaigns ------------------------
-
-export async function saveCompanyToCrm(payload: { company_id: string; company_name: string; notes?: string|null; source?: string }) {
-  const res = await fetch(`${API_BASE}/crm/saveCompany`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json' },
-    body: JSON.stringify({ ...payload, source: payload.source ?? 'search' })
+export async function searchCompanies(filters: SearchFilters): Promise<SearchCompaniesResponse> {
+  const payload = buildPayload(filters);
+  const res = await fetch(`${GW}/public/searchCompanies`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`saveCompany ${res.status}:${t.slice(0,200)}`);
+    const text = await res.text().catch(() => "");
+    throw new Error(`Search failed: ${res.status} ${text}`);
   }
-  return res.json();
+  return (await res.json()) as SearchCompaniesResponse;
 }
-
-export async function enrichCompany(payload: { company_id: string }) {
-  const res = await fetch(`${API_BASE}/crm/enrich`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`enrich ${res.status}:${t.slice(0,200)}`);
-  }
-  return res.json();
-}
-
-export async function recallCompany(payload: { company_id: string; questions?: string[] }) {
-  const vendor = (process.env.NEXT_PUBLIC_AI_VENDOR || (import.meta as any)?.env?.VITE_AI_VENDOR || 'gemini');
-  const res = await fetch(`${API_BASE}/ai/recall`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json', 'x-ai-vendor': String(vendor) },
-    body: JSON.stringify(payload)
-  });
-  if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`recall ${res.status}:${t.slice(0,200)}`);
-  }
-  return res.json();
-}
-
-export async function saveCampaign(payload: { name: string; company_ids: string[]; channel: 'email'|'linkedin'; persona?: string; template_id?: string; }) {
-  const res = await fetch(`${API_BASE}/crm/campaigns`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'accept': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`saveCampaign ${res.status}:${t.slice(0,200)}`);
-  }
-  return res.json();
-}
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Routes `searchCompanies` to API Gateway and sends CSV string filters, updating types and removing legacy helpers/endpoints.
> 
> - **API (frontend/src/lib/api.ts)**:
>   - **Search**:
>     - Replaces legacy search with `searchCompanies` posting to `${GW}/public/searchCompanies`.
>     - Builds payload from `SearchFilters`, converting `origin`/`dest`/`hs` arrays to CSV via `toCsv`, with bounded `limit`/`offset`.
>     - Returns typed `SearchCompaniesResponse` with `rows: SearchCompanyRow[]` and `meta`.
>   - **Types**: Adds `SearchFilters`, `SearchCompanyRow`, `SearchCompaniesResponse`.
>   - **Cleanup**: Removes legacy API client, shipment/filter widgets, and CRM/AI endpoints formerly in `api.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46a70d58baa2918e1afccd3b7ca123592b12e547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->