### PR TITLE
fix(onboarding): remove org_members bypasses so regular signups hit /…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,28 +62,29 @@ const SectorLandingPage = lazy(() => import("@/pages/landing/SectorLandingPage")
 const DEMO_MODE = !import.meta.env.VITE_SUPABASE_URL;
 
 function RequireAuth({ children }) {
-  const { user, loading, isSuperAdmin, orgId } = useAuth();
+  const { user, loading, isSuperAdmin } = useAuth();
   const location = useLocation();
   if (DEMO_MODE) return children;
   if (loading) return null;
   if (!user) return <Navigate to="/login?next=/app/dashboard" replace />;
 
   const meta = user?.user_metadata || {};
-  // Primary: explicit flag written at signup / after onboarding
-  // Secondary: account < 2 h old without an explicit true = treat as new signup
+  // Primary: explicit flag written at signup / after onboarding.
+  // Secondary: account < 2 h old without an explicit true = treat as new signup.
+  //
+  // NOTE: do NOT bypass the gate based on org_members membership. Every
+  // regular signup auto-gets an org_members row via the
+  // `on_new_user_org_bootstrap` DB trigger BEFORE going through the 6-step
+  // wizard — the wizard customizes that auto-created workspace. Invited
+  // users already have onboarding_completed=true written server-side by
+  // accept-workspace-invite / signup-with-invite, so the metadata gate
+  // routes them straight to the dashboard without needing a bypass here.
   const accountAgeHours = (Date.now() - new Date(user?.created_at || 0).getTime()) / 3_600_000;
   const onboardingDone =
     meta.onboarding_completed === true ||
     (meta.onboarding_completed !== false && accountAgeHours >= 2);
 
-  // Workspace membership IS onboarding. Invited users who joined via
-  // /accept-invite have an active org_members row; they should bypass the
-  // new-org wizard regardless of the onboarding_completed metadata race.
-  // This also covers the brief window where updateUser() hasn't propagated
-  // to AuthProvider yet after a successful invite acceptance.
-  const hasWorkspace = Boolean(orgId);
-
-  if (!isSuperAdmin && !onboardingDone && !hasWorkspace && location.pathname !== "/onboarding") {
+  if (!isSuperAdmin && !onboardingDone && location.pathname !== "/onboarding") {
     return <Navigate to="/onboarding" replace />;
   }
   return children;

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -66,33 +66,19 @@ export default function AuthCallback() {
           return;
         }
 
-        // Bulletproof: if the user already has a workspace membership, they're
-        // done with onboarding regardless of metadata. Joining a workspace IS
-        // onboarding. Handles the case where email confirmation arrived AFTER
-        // the user already accepted an invite (server-side metadata write may
-        // not have propagated to this JWT yet).
-        let hasWorkspaceMembership = false;
-        try {
-          const { data: memberships } = await auth
-            .from('org_members')
-            .select('id')
-            .eq('user_id', user.id)
-            .eq('status', 'active')
-            .limit(1);
-          hasWorkspaceMembership = Array.isArray(memberships) && memberships.length > 0;
-        } catch {
-          // If the query fails (RLS or network), fall through to metadata check.
-          hasWorkspaceMembership = false;
-        }
-
-        if (hasWorkspaceMembership) {
-          // Mark onboarding complete and route straight to the dashboard.
-          if (meta.onboarding_completed !== true) {
-            await auth.auth.updateUser({ data: { onboarding_completed: true } });
-          }
-          navigate(nextParam && !nextParam.includes('/onboarding') ? nextParam : '/app/dashboard', { replace: true });
-          return;
-        }
+        // NOTE: do NOT short-circuit on "user has org_members row" here.
+        // Every regular signup auto-gets an org_members row via the
+        // `on_new_user_org_bootstrap` DB trigger BEFORE going through the
+        // 6-step onboarding wizard. The wizard customizes the auto-created
+        // workspace (name, industry, plan, team). Skipping the gate based
+        // on membership breaks regular signup.
+        //
+        // Invite flows already write onboarding_completed=true server-side
+        // (accept-workspace-invite via admin.auth.admin.updateUserById;
+        // signup-with-invite via createUser's user_metadata). That value
+        // is present in the JWT minted by email-confirmation verifyOtp,
+        // so the metadata gate below correctly routes invitees to the
+        // dashboard while regular signups go to /onboarding.
 
         // Primary: flag written at registration via signUp options.data
         // Secondary: account < 30 min old = first confirmation click


### PR DESCRIPTION
…onboarding

Companion to 7d13017c (which dropped the org_members trigger). Removes the two CLIENT-SIDE bypasses that were the other half of the same mistake:

- frontend/src/App.jsx RequireAuth.hasWorkspace check: every regular signup has an org_members row from the on_new_user_org_bootstrap trigger BEFORE going through onboarding, so the hasWorkspace bypass skipped onboarding for every new user. Reverted to the original meta.onboarding_completed gate.

- frontend/src/pages/AuthCallback.tsx hasWorkspaceMembership query: same root cause. The block queried org_members and short-circuited to /app/dashboard whenever found, breaking regular signups.

Invite flow continues to work because:
- accept-workspace-invite sets onboarding_completed=true server-side via admin.auth.admin.updateUserById before responding.
- signup-with-invite bakes onboarding_completed=true into createUser's user_metadata, so the very first JWT carries it.
- AuthCallback retains the isInviteFlow short-circuit for nextParam starting with /accept-invite (covers the rare case of a recovered next param).