### PR TITLE
chore(pulse): bump in-app Pulse Explorer header badge V1 → V2

### DIFF
--- a/frontend/src/features/pulse/explore/ExploreHeader.jsx
+++ b/frontend/src/features/pulse/explore/ExploreHeader.jsx
@@ -73,7 +73,7 @@ export default function ExploreHeader({
         <div className="flex items-center gap-2 font-display shrink-0">
           <Sparkles className="text-cyan-400" size={18} />
           <span className="font-semibold text-sm tracking-tight whitespace-nowrap">Pulse Explorer</span>
-          <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 uppercase tracking-wider">V1</span>
+          <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 uppercase tracking-wider">V2</span>
         </div>
         <form
           onSubmit={(e) => { e.preventDefault(); onSubmit?.(); }}


### PR DESCRIPTION
Marketing surfaces (logisticintel.com/company-intelligence and /pulse) were just rebuilt around "Pulse Explorer V2" — the live app still showed "V1" in the header badge (frontend/src/features/pulse/explore/ ExploreHeader.jsx:76), creating a visible product/marketing version drift on every sales call.

Cosmetic only — does not change feature parity. If features marketed as V2 don't exist in the live app, that's a separate scope decision (see CEO review 2026-06-18).