### PR TITLE
feat(pulse): Studio White redesign for Pulse Executive Account Brief

### DIFF
--- a/frontend/src/lib/pulse/exportPulseExecutivePdf.ts
+++ b/frontend/src/lib/pulse/exportPulseExecutivePdf.ts
@@ -1,71 +1,133 @@
 /**
- * Executive Pre-Call Brief PDF — premium-grade companion to the existing
- * exportPulseBriefPdf.ts.
+ * Pulse Executive Account Brief — Studio White corporate blueprint.
  *
- * Where the original brief reads like a sales-rep prep doc, this one is
- * built for execs scanning before a 30-minute discovery call. Every page
- * earns its place: cover with grade, at-a-glance infographic page,
- * pre-call talking points, objections + responses, best-contact, trade
- * lane breakdown, sources.
+ * Premium light-mode PDF read by enterprise execs in 60 seconds before
+ * a discovery call. Four-part structure (rewritten 2026-06-18):
  *
- * Brand: LIT navy + electric cyan + the pulse mark drawn natively (same
- * system as the Explorer PDF in pulseReportPdf.js).
+ *   1. Header & enterprise metadata block — title, freshness badge,
+ *      sub-header with parent / NAICS / HQ / port gateway, opportunity
+ *      index (score + letter grade).
+ *   2. Executive macro briefing — a single dense paragraph linking
+ *      public financial standing to internal supply-chain operational
+ *      impacts.
+ *   3. Sourcing demand & logistics volumetrics — 3-column metric grid
+ *      (annual TEU + tier, active freight lanes, primary carrier mix)
+ *      followed by the top-3 trade lane velocity table.
+ *   4. Metric-based friction points & value hypotheses — two-column
+ *      table mapping a specific supply-chain stressor to a specific
+ *      LIT platform feature that mitigates it.
  *
- * Falls back gracefully when `executive_overview` is missing (older
- * cached briefs from before the schema extension): renders a "Refresh
- * this brief to generate the executive view" placeholder page and uses
- * the legacy report fields where possible.
+ *   + Supply chain leadership enrichment: exactly 2 logistics decision-
+ *     makers (Chief Supply Chain Officer / VP Logistics / VP Inventory
+ *     Management tier). Marketing / creative / PR contacts are
+ *     filtered out at both LLM schema and renderer level.
+ *
+ * Hard exclusions (enforced at both the LLM and the renderer):
+ *   - No SDR outreach scripts, opening lines, hooks, email templates.
+ *   - No talking points or objection-and-response blocks.
+ *   - No dark-mode chrome or slate-on-navy components.
+ *   - No marketing / brand / PR / creative contacts.
+ *   - Missing values render as `[Enrichment in Progress]` pill badges.
+ *
+ * Falls back gracefully when an older brief without the new
+ * executive_overview shape is passed in — every block independently
+ * renders the pending badge if its data is missing.
  */
 
 import jsPDF from "jspdf";
-import autoTable from "jspdf-autotable";
+import autoTable, { type RowInput } from "jspdf-autotable";
 
-// ─── LIT brand palette (mirrors Pulse Explorer PDF) ───────────────────────
-const LIT_NAVY: [number, number, number] = [2, 6, 23];        // #020617
-const LIT_NAVY_SOFT: [number, number, number] = [15, 24, 40]; // #0F1828
-const LIT_CYAN_NEON: [number, number, number] = [0, 224, 255];// #00E0FF
-const LIT_CYAN_600: [number, number, number] = [8, 145, 178]; // #0891B2
-const LIT_CYAN_50: [number, number, number] = [236, 254, 255];// #ECFEFF
-const LIT_SLATE_900: [number, number, number] = [15, 23, 42];
-const LIT_SLATE_700: [number, number, number] = [51, 65, 85];
-const LIT_SLATE_600: [number, number, number] = [71, 85, 105];
-const LIT_SLATE_400: [number, number, number] = [148, 163, 184];
-const LIT_SLATE_200: [number, number, number] = [226, 232, 240];
-const LIT_EMERALD_600: [number, number, number] = [5, 150, 105];
-const LIT_AMBER_500: [number, number, number] = [245, 158, 11];
-const LIT_RED_600: [number, number, number] = [220, 38, 38];
+// ─── Studio White palette ─────────────────────────────────────────────────
+const WHITE: [number, number, number] = [255, 255, 255];
+const INK_900: [number, number, number] = [15, 23, 42];
+const INK_800: [number, number, number] = [30, 41, 59];
+const INK_700: [number, number, number] = [51, 65, 85];
+const INK_500: [number, number, number] = [100, 116, 139];
+const INK_400: [number, number, number] = [148, 163, 184];
+const INK_300: [number, number, number] = [203, 213, 225];
+const INK_200: [number, number, number] = [226, 232, 240];
+const INK_100: [number, number, number] = [241, 245, 249];
+const INK_50:  [number, number, number] = [248, 250, 252];
 
-const GRADE_COLOR: Record<string, [number, number, number]> = {
-  A: LIT_EMERALD_600,
-  B: LIT_CYAN_600,
-  C: LIT_AMBER_500,
-  D: LIT_RED_600,
+const STATUS_OK_BG:        [number, number, number] = [220, 252, 231];
+const STATUS_OK_FG:        [number, number, number] = [21, 128, 61];
+const STATUS_WARN_BG:      [number, number, number] = [254, 243, 199];
+const STATUS_WARN_FG:      [number, number, number] = [180, 83, 9];
+const STATUS_GROWING_BG:   [number, number, number] = [219, 234, 254];
+const STATUS_GROWING_FG:   [number, number, number] = [29, 78, 216];
+const STATUS_DECLINING_BG: [number, number, number] = [254, 226, 226];
+const STATUS_DECLINING_FG: [number, number, number] = [185, 28, 28];
+const STATUS_NEUTRAL_BG:   [number, number, number] = [241, 245, 249];
+const STATUS_NEUTRAL_FG:   [number, number, number] = [30, 41, 59];
+
+const PENDING_BG: [number, number, number] = [254, 249, 195];
+const PENDING_FG: [number, number, number] = [161, 98, 7];
+
+const GRADE_FG: Record<string, [number, number, number]> = {
+  A: STATUS_OK_FG,
+  B: STATUS_GROWING_FG,
+  C: STATUS_WARN_FG,
+  D: STATUS_DECLINING_FG,
 };
 
-// ─── Pulse mark — re-drawn natively (no asset to embed) ───────────────────
-function drawPulseLogo(doc: jsPDF, x: number, y: number, size: number): void {
-  const s = size / 64;
-  doc.setFillColor(...LIT_NAVY);
-  doc.roundedRect(x, y, size, size, size * 0.25, size * 0.25, "F");
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(s * 4.8);
-  doc.setLineCap("round");
-  doc.setLineJoin("round");
-  const pts: Array<[number, number]> = [
-    [8, 32], [20, 32], [26, 22], [32, 42], [38, 32], [56, 32],
-  ];
-  for (let i = 1; i < pts.length; i++) {
-    doc.line(x + pts[i - 1][0] * s, y + pts[i - 1][1] * s, x + pts[i][0] * s, y + pts[i][1] * s);
-  }
-  doc.setFillColor(...LIT_CYAN_NEON);
-  doc.circle(x + 56 * s, y + 32 * s, 3 * s, "F");
+// ─── Page geometry (Letter portrait) ──────────────────────────────────────
+const PAGE_W = 612;
+const PAGE_H = 792;
+const MARGIN = 40;
+const CONTENT_W = PAGE_W - MARGIN * 2;
+const HEADER_H = 56;
+const FOOTER_H = 30;
+
+const PENDING_TEXT = "[Enrichment in Progress]";
+
+// ─── Types — mirror the pulse-ai-enrich schema (Studio White redesign) ────
+interface CorporateMetadata {
+  parent_company?: string;
+  naics_sector?: string;
+  headquarters_location?: string;
+  primary_port_gateway?: string;
 }
 
-// ─── Types — kept loose because the upstream brief is permissive ──────────
+interface LogisticsVolumetrics {
+  annual_teu_estimate?: string;
+  importer_tier?: string;
+  active_freight_lanes_count?: number;
+  primary_carriers?: string[];
+}
+
+interface TradeLaneRow {
+  route?: string;
+  volume_share_pct?: number;
+  transit_days?: number;
+  velocity_status?: string;
+}
+
+interface FrictionPoint {
+  stressor?: string;
+  value_hypothesis?: string;
+}
+
+interface LeadershipContact {
+  name?: string;
+  title?: string;
+  strategic_mandate?: string;
+}
+
 interface ExecutiveOverview {
-  tldr?: string[];
+  // New (Studio White) fields
+  corporate_metadata?: CorporateMetadata;
   opportunity_grade_letter?: "A" | "B" | "C" | "D";
   opportunity_score_0_to_100?: number;
+  data_freshness_label?: string;
+  executive_macro_briefing?: string;
+  logistics_volumetrics?: LogisticsVolumetrics;
+  trade_lane_velocity?: TradeLaneRow[];
+  friction_points?: FrictionPoint[];
+  supply_chain_leadership?: LeadershipContact[];
+
+  // Legacy fields — read with permissive fallback so a cached
+  // pre-redesign brief still renders a partial Studio White PDF
+  // instead of crashing. Never rendered as sales copy.
   key_metrics_snapshot?: {
     shipments_12m?: string;
     teu_12m?: string;
@@ -74,24 +136,11 @@ interface ExecutiveOverview {
     recent_activity_summary?: string;
     freshness_label?: string;
   };
-  pre_call_talking_points?: string[];
-  likely_objections?: Array<{ objection: string; response: string }>;
-  best_contact_and_approach?: {
-    contact_name?: string;
-    contact_title?: string;
-    channel?: string;
-    opening_line?: string;
-  };
 }
 
 interface BriefReport {
   company_summary?: string;
   why_now?: string;
-  sales_angle?: string;
-  buying_signals?: string[];
-  risk_flags?: string[];
-  lane_insights?: string[];
-  web_sources?: Array<{ title?: string; url?: string; publisher?: string; published_at?: string; summary?: string }>;
   executive_overview?: ExecutiveOverview;
 }
 
@@ -104,736 +153,613 @@ interface ExportArgs {
   generatedAt?: Date;
 }
 
-// ─── Layout constants (Letter portrait) ───────────────────────────────────
-const PAGE_W = 612;
-const PAGE_H = 792;
-const MARGIN = 40;
-const CONTENT_W = PAGE_W - MARGIN * 2;
-const HEADER_H = 70;
-const FOOTER_H = 28;
-
-export function exportPulseExecutivePdf(args: ExportArgs): void {
-  const doc = new jsPDF({ unit: "pt", format: "letter" });
-  const generatedAt = args.generatedAt ?? new Date();
-  const ov: ExecutiveOverview = args.brief?.report?.executive_overview ?? {};
-  const report: BriefReport = args.brief?.report ?? {};
-
-  // Page 1: Cover — branded hero, grade circle, exec TLDR
-  drawCoverPage(doc, args, ov, generatedAt);
-
-  // Page 2: At-a-glance — KPI tiles + opportunity gauge + key metrics
-  doc.addPage();
-  drawAtAGlancePage(doc, args, ov);
-
-  // Page 3: Why now + buying signals + risk flags
-  doc.addPage();
-  drawWhyNowPage(doc, report);
-
-  // Page 4: Pre-call talking points
-  doc.addPage();
-  drawTalkingPointsPage(doc, ov);
-
-  // Page 5: Likely objections + responses
-  doc.addPage();
-  drawObjectionsPage(doc, ov);
-
-  // Page 6: Best contact + opening line
-  doc.addPage();
-  drawBestContactPage(doc, ov);
-
-  // Page 7: Trade lane intel
-  doc.addPage();
-  drawLaneIntelPage(doc, report);
-
-  // Page 8: Sources
-  doc.addPage();
-  drawSourcesPage(doc, report);
-
-  // Footer on every page after page 1 has the same hero header
-  stampHeaderAndFooter(doc, args.companyName);
-
-  const slug = args.companyName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-  const dateStamp = generatedAt.toISOString().slice(0, 10);
-  doc.save(`LIT-Executive-Brief-${slug || "company"}-${dateStamp}.pdf`);
-}
-
-// ─── PAGE 1 · Cover ───────────────────────────────────────────────────────
-function drawCoverPage(
-  doc: jsPDF,
-  args: ExportArgs,
-  ov: ExecutiveOverview,
-  generatedAt: Date,
-): void {
-  // Full-bleed navy background for the upper third
-  doc.setFillColor(...LIT_NAVY);
-  doc.rect(0, 0, PAGE_W, 220, "F");
-  // Neon cyan accent line
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(2);
-  doc.line(0, 220, PAGE_W, 220);
-
-  // Pulse mark + brand wordmark, top-left
-  drawPulseLogo(doc, MARGIN, 24, 38);
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(14);
-  doc.setTextColor(255, 255, 255);
-  doc.text("LIT  ·  PULSE EXECUTIVE BRIEF", MARGIN + 50, 44);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(9);
-  doc.setTextColor(...LIT_CYAN_NEON);
-  doc.text("Pre-call account intelligence", MARGIN + 50, 58);
-
-  // Generated stamp — moved BELOW the company name on the left, so it
-  // doesn't collide with the opportunity grade circle on the right.
-  // Old layout had the date + freshness chip at top-right where the
-  // circle now sits, causing both to overlap (visible in user feedback).
-
-  // Company name (large, white) — left side, full width minus circle pad
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(36);
-  doc.setTextColor(255, 255, 255);
-  const companyLines = doc.splitTextToSize(args.companyName, CONTENT_W - 130);
-  doc.text(companyLines[0] ?? args.companyName, MARGIN, 130);
-
-  // Sub-meta line: domain · industry · HQ
-  const subBits = [args.domain, args.industry, args.hq].filter(Boolean).join(" · ");
-  if (subBits) {
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(11);
-    doc.setTextColor(...LIT_SLATE_400);
-    doc.text(subBits, MARGIN, 154);
-  }
-
-  // Date + freshness chip — small, below sub-meta line, left side.
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(9);
-  doc.setTextColor(...LIT_SLATE_400);
-  const dateLine = generatedAt.toLocaleString("en-US", {
-    year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
-  });
-  doc.text(dateLine, MARGIN, 178);
-  const freshness = ov.key_metrics_snapshot?.freshness_label;
-  if (freshness) {
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text(`  ·  ${freshness}`, MARGIN + doc.getTextWidth(dateLine), 178);
-  }
-
-  // Opportunity grade circle, right side — clear of left text now.
-  const grade = ov.opportunity_grade_letter ?? "—";
-  const score = ov.opportunity_score_0_to_100;
-  drawGradeCircle(doc, PAGE_W - MARGIN - 50, 110, 48, grade, score);
-
-  // Below the hero: the 3-bullet TLDR card on a light background
-  doc.setFillColor(248, 250, 252);
-  doc.rect(0, 220, PAGE_W, PAGE_H - 220, "F");
-
-  let y = 260;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_CYAN_600);
-  doc.text("EXECUTIVE TL;DR", MARGIN, y);
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(1.2);
-  doc.line(MARGIN, y + 4, MARGIN + 60, y + 4);
-  y += 22;
-
-  const tldr = ov.tldr && ov.tldr.length ? ov.tldr : ["—", "—", "—"];
-  for (let i = 0; i < tldr.length; i++) {
-    const num = String(i + 1).padStart(2, "0");
-    doc.setFillColor(...LIT_NAVY);
-    doc.roundedRect(MARGIN, y, 28, 28, 6, 6, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(11);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text(num, MARGIN + 14, y + 19, { align: "center" });
-
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(11.5);
-    doc.setTextColor(...LIT_SLATE_900);
-    const wrapped = doc.splitTextToSize(stripMarkdown(tldr[i] ?? "—"), CONTENT_W - 40);
-    let cy = y + 14;
-    for (const line of wrapped) {
-      doc.text(line, MARGIN + 40, cy);
-      cy += 14;
-    }
-    y = cy + 12;
-  }
-
-  // Footer-strip CTA: "Read in 60 seconds before the call."
-  doc.setFillColor(...LIT_NAVY);
-  doc.rect(0, PAGE_H - 70, PAGE_W, 70, "F");
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(0.8);
-  doc.line(0, PAGE_H - 70, PAGE_W, PAGE_H - 70);
-  drawPulseLogo(doc, MARGIN, PAGE_H - 55, 22);
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(11);
-  doc.setTextColor(255, 255, 255);
-  doc.text("Read this in 60 seconds. Walk into the call ready.", MARGIN + 32, PAGE_H - 42);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(9);
-  doc.setTextColor(...LIT_CYAN_NEON);
-  doc.text("logisticintel.com  ·  Pulse AI", MARGIN + 32, PAGE_H - 28);
-}
-
-// Opportunity grade — outlined circle, big letter, score below
-function drawGradeCircle(
-  doc: jsPDF,
-  cx: number, cy: number, r: number,
-  grade: string, score?: number,
-): void {
-  const color = GRADE_COLOR[grade] ?? LIT_SLATE_400;
-  doc.setFillColor(255, 255, 255);
-  doc.circle(cx, cy, r, "F");
-  doc.setDrawColor(...color);
-  doc.setLineWidth(3);
-  doc.circle(cx, cy, r, "S");
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(48);
-  doc.setTextColor(...color);
-  doc.text(grade, cx, cy + 12, { align: "center" });
-  if (typeof score === "number" && Number.isFinite(score)) {
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(8.5);
-    doc.setTextColor(...LIT_SLATE_400);
-    doc.text(`${Math.round(score)} / 100`, cx, cy + 28, { align: "center" });
-  }
-  doc.setFontSize(7.5);
-  doc.setTextColor(...LIT_SLATE_400);
-  doc.text("OPPORTUNITY", cx, cy - r - 8, { align: "center" });
-}
-
-// ─── PAGE 2 · At-a-glance (infographic KPIs) ──────────────────────────────
-function drawAtAGlancePage(doc: jsPDF, args: ExportArgs, ov: ExecutiveOverview): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("At a glance", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("The numbers that frame this call.", MARGIN, y + 16);
-  y += 50;
-
-  const km = ov.key_metrics_snapshot ?? {};
-  // Build the full set, then filter out the "N/A" / unknown ones so
-  // companies with no shipment data (B2B retailers etc.) get a clean
-  // page of populated tiles instead of a wall of N/A.
-  const isBlank = (v: string | undefined) =>
-    !v || /^(n\/a|na|—|-)$/i.test(v.trim());
-  const allTiles: Array<{ label: string; value: string }> = [
-    { label: "SHIPMENTS · 12M", value: km.shipments_12m ?? "" },
-    { label: "TEU · 12M", value: km.teu_12m ?? "" },
-    { label: "TOP LANE", value: km.top_lane ?? "" },
-    { label: "TOP CARRIER", value: km.top_carrier ?? "" },
-    { label: "RECENT ACTIVITY", value: stripMarkdown(km.recent_activity_summary ?? "") },
-    { label: "DATA FRESHNESS", value: km.freshness_label ?? "" },
-  ];
-  const tiles = allTiles.filter((t) => !isBlank(t.value));
-  if (tiles.length === 0) {
-    // Nothing populated — fall back to a single big placeholder card
-    // rather than 6 empty navy boxes.
-    drawPlaceholder(
-      doc,
-      "Shipment data not yet available for this company. Refresh the brief once live KPIs are populated.",
-      y,
-    );
-    return;
-  }
-
-  // 3 cols, rows as needed. Adapt to count.
-  const colW = (CONTENT_W - 20) / 3;
-  const rowH = 90;
-  for (let i = 0; i < tiles.length; i++) {
-    const col = i % 3;
-    const row = Math.floor(i / 3);
-    const tx = MARGIN + col * (colW + 10);
-    const ty = y + row * (rowH + 12);
-    // Tile background
-    doc.setFillColor(...LIT_NAVY);
-    doc.roundedRect(tx, ty, colW, rowH, 10, 10, "F");
-    doc.setDrawColor(...LIT_CYAN_NEON);
-    doc.setLineWidth(0.6);
-    doc.line(tx + 16, ty + rowH - 12, tx + 38, ty + rowH - 12);
-
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(8.5);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text(tiles[i].label, tx + 14, ty + 22);
-
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(15);
-    doc.setTextColor(255, 255, 255);
-    const wrapped = doc.splitTextToSize(stripMarkdown(tiles[i].value), colW - 28);
-    let vy = ty + 44;
-    for (const line of wrapped.slice(0, 3)) {
-      doc.text(line, tx + 14, vy);
-      vy += 18;
-    }
-  }
-  // Advance y based on the actual number of rows rendered, not hard-coded 2.
-  const renderedRows = Math.ceil(tiles.length / 3);
-  y += rowH * renderedRows + (renderedRows - 1) * 12 + 30;
-
-  // Opportunity gauge — visual bar instead of arc (more readable on print)
-  const score = ov.opportunity_score_0_to_100;
-  if (typeof score === "number") {
-    y += 10;
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(10);
-    doc.setTextColor(...LIT_CYAN_600);
-    doc.text("OPPORTUNITY GAUGE", MARGIN, y);
-    doc.setDrawColor(...LIT_CYAN_NEON);
-    doc.setLineWidth(1.2);
-    doc.line(MARGIN, y + 4, MARGIN + 80, y + 4);
-    y += 24;
-
-    const gaugeW = CONTENT_W;
-    const gaugeH = 18;
-    // Background track
-    doc.setFillColor(...LIT_SLATE_200);
-    doc.roundedRect(MARGIN, y, gaugeW, gaugeH, gaugeH / 2, gaugeH / 2, "F");
-    // Filled portion
-    const fillW = Math.max(gaugeH, (gaugeW * Math.min(100, Math.max(0, score))) / 100);
-    const grade = ov.opportunity_grade_letter ?? "C";
-    const color = GRADE_COLOR[grade] ?? LIT_CYAN_600;
-    doc.setFillColor(...color);
-    doc.roundedRect(MARGIN, y, fillW, gaugeH, gaugeH / 2, gaugeH / 2, "F");
-    // Tick markers + labels
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(8);
-    doc.setTextColor(...LIT_SLATE_400);
-    const ticks = [0, 25, 50, 75, 100];
-    for (const t of ticks) {
-      const tx = MARGIN + (gaugeW * t) / 100;
-      doc.text(String(t), tx, y + gaugeH + 12, { align: "center" });
-    }
-    // Score callout, top of gauge
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(10);
-    doc.setTextColor(...LIT_SLATE_900);
-    doc.text(`${Math.round(score)} / 100  ·  Grade ${grade}`, MARGIN, y - 6);
-  }
-}
-
-// ─── PAGE 3 · Why now + buying signals + risk flags ───────────────────────
-function drawWhyNowPage(doc: jsPDF, report: BriefReport): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Why now", MARGIN, y);
-  y += 30;
-
-  if (report.why_now) {
-    y = drawParagraph(doc, report.why_now, y);
-    y += 12;
-  }
-  if (report.sales_angle) {
-    y = drawSection(doc, "SALES ANGLE", LIT_CYAN_600, y);
-    y = drawParagraph(doc, report.sales_angle, y);
-    y += 18;
-  }
-  if (report.buying_signals?.length) {
-    y = drawSection(doc, "BUYING SIGNALS", LIT_EMERALD_600, y);
-    y = drawChipList(doc, report.buying_signals, LIT_EMERALD_600, y);
-    y += 18;
-  }
-  if (report.risk_flags?.length) {
-    y = drawSection(doc, "RISK FLAGS", LIT_RED_600, y);
-    y = drawChipList(doc, report.risk_flags, LIT_RED_600, y);
-  }
-}
-
-// ─── PAGE 4 · Pre-call talking points ─────────────────────────────────────
-function drawTalkingPointsPage(doc: jsPDF, ov: ExecutiveOverview): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Pre-call talking points", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("Read these in the first 90 seconds. Order matters.", MARGIN, y + 16);
-  y += 50;
-
-  const items = ov.pre_call_talking_points ?? [];
-  if (!items.length) {
-    drawPlaceholder(doc, "Refresh the brief to generate pre-call talking points.", y);
-    return;
-  }
-  for (let i = 0; i < items.length; i++) {
-    // Number badge
-    doc.setFillColor(...LIT_NAVY);
-    doc.roundedRect(MARGIN, y - 4, 30, 30, 6, 6, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(13);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text(String(i + 1), MARGIN + 15, y + 16, { align: "center" });
-
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(12);
-    doc.setTextColor(...LIT_SLATE_900);
-    const wrapped = doc.splitTextToSize(stripMarkdown(items[i]), CONTENT_W - 50);
-    let ly = y + 14;
-    for (const line of wrapped) {
-      doc.text(line, MARGIN + 44, ly);
-      ly += 16;
-    }
-    y = ly + 16;
-  }
-}
-
-// ─── PAGE 5 · Likely objections ───────────────────────────────────────────
-function drawObjectionsPage(doc: jsPDF, ov: ExecutiveOverview): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Likely objections", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("What they'll push back on — and how to land the response.", MARGIN, y + 16);
-  y += 50;
-
-  const items = ov.likely_objections ?? [];
-  if (!items.length) {
-    drawPlaceholder(doc, "Refresh the brief to generate likely objections.", y);
-    return;
-  }
-  for (const it of items) {
-    // Objection card
-    doc.setFillColor(...LIT_CYAN_50);
-    doc.roundedRect(MARGIN, y, CONTENT_W, 64, 8, 8, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(9);
-    doc.setTextColor(...LIT_CYAN_600);
-    doc.text("OBJECTION", MARGIN + 14, y + 18);
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(11);
-    doc.setTextColor(...LIT_SLATE_900);
-    const obj = doc.splitTextToSize(stripMarkdown(it.objection), CONTENT_W - 28);
-    let oy = y + 34;
-    for (const line of obj) {
-      doc.text(line, MARGIN + 14, oy);
-      oy += 14;
-    }
-    const objH = Math.max(64, oy - y + 8);
-
-    // Response card
-    const ry = y + objH + 6;
-    doc.setFillColor(...LIT_NAVY);
-    doc.roundedRect(MARGIN, ry, CONTENT_W, 64, 8, 8, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(9);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text("YOUR RESPONSE", MARGIN + 14, ry + 18);
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(11);
-    doc.setTextColor(255, 255, 255);
-    const resp = doc.splitTextToSize(stripMarkdown(it.response), CONTENT_W - 28);
-    let ry2 = ry + 34;
-    for (const line of resp) {
-      doc.text(line, MARGIN + 14, ry2);
-      ry2 += 14;
-    }
-    const respH = Math.max(64, ry2 - ry + 8);
-    y = ry + respH + 16;
-  }
-}
-
-// ─── PAGE 6 · Best contact ────────────────────────────────────────────────
-function drawBestContactPage(doc: jsPDF, ov: ExecutiveOverview): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Who to call first", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("The single highest-leverage opener.", MARGIN, y + 16);
-  y += 60;
-
-  const c = ov.best_contact_and_approach ?? {};
-  if (!c.contact_name && !c.opening_line) {
-    drawPlaceholder(doc, "Refresh the brief to generate the best-contact recommendation.", y);
-    return;
-  }
-
-  // Contact card
-  doc.setFillColor(...LIT_NAVY);
-  doc.roundedRect(MARGIN, y, CONTENT_W, 140, 12, 12, "F");
-
-  // Initials avatar
-  const initials = (c.contact_name ?? "?")
-    .split(/\s+/).map((s) => s[0]).filter(Boolean).slice(0, 2).join("").toUpperCase();
-  doc.setFillColor(...LIT_CYAN_NEON);
-  doc.circle(MARGIN + 50, y + 70, 28, "F");
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_NAVY);
-  doc.text(initials, MARGIN + 50, y + 78, { align: "center" });
-
-  // Name + title
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(18);
-  doc.setTextColor(255, 255, 255);
-  doc.text(c.contact_name ?? "—", MARGIN + 100, y + 60);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(11);
-  doc.setTextColor(...LIT_CYAN_NEON);
-  doc.text(c.contact_title ?? "—", MARGIN + 100, y + 80);
-
-  // Channel chip
-  if (c.channel) {
-    doc.setFillColor(...LIT_CYAN_NEON);
-    doc.roundedRect(MARGIN + 100, y + 92, 70, 18, 4, 4, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(8.5);
-    doc.setTextColor(...LIT_NAVY);
-    doc.text(c.channel.toUpperCase(), MARGIN + 135, y + 104, { align: "center" });
-  }
-
-  y += 160;
-
-  // Opening line block
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_CYAN_600);
-  doc.text("OPENING LINE", MARGIN, y);
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(1.2);
-  doc.line(MARGIN, y + 4, MARGIN + 60, y + 4);
-  y += 22;
-
-  doc.setFillColor(...LIT_CYAN_50);
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(0.6);
-  // Light quote-block
-  const line = stripMarkdown(c.opening_line ?? "—");
-  const wrapped = doc.splitTextToSize(line, CONTENT_W - 28);
-  const blockH = Math.max(70, wrapped.length * 16 + 28);
-  doc.roundedRect(MARGIN, y, CONTENT_W, blockH, 8, 8, "FD");
-  doc.setFont("helvetica", "italic");
-  doc.setFontSize(12);
-  doc.setTextColor(...LIT_SLATE_900);
-  let qy = y + 22;
-  for (const w of wrapped) {
-    doc.text(`"${qy === y + 22 ? w : "  " + w}"`.replace(/^""$/, ""), MARGIN + 14, qy);
-    qy += 16;
-  }
-}
-
-// ─── PAGE 7 · Trade lane intel (existing report data) ─────────────────────
-function drawLaneIntelPage(doc: jsPDF, report: BriefReport): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Trade lane intel", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("Where the freight actually moves.", MARGIN, y + 16);
-  y += 50;
-
-  const lanes = report.lane_insights ?? [];
-  if (!lanes.length) {
-    drawPlaceholder(doc, "No lane insights available in this brief.", y);
-    return;
-  }
-  // Render as a numbered, accented list
-  for (let i = 0; i < lanes.length; i++) {
-    // Lane chip on the left
-    doc.setFillColor(...LIT_CYAN_50);
-    doc.setDrawColor(...LIT_CYAN_NEON);
-    doc.setLineWidth(0.4);
-    const wrapped = doc.splitTextToSize(stripMarkdown(lanes[i]), CONTENT_W - 50);
-    const cardH = wrapped.length * 14 + 24;
-    doc.roundedRect(MARGIN, y, CONTENT_W, cardH, 6, 6, "FD");
-    // Number circle
-    doc.setFillColor(...LIT_NAVY);
-    doc.circle(MARGIN + 18, y + 18, 11, "F");
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(10);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text(String(i + 1), MARGIN + 18, y + 22, { align: "center" });
-    // Text
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(10.5);
-    doc.setTextColor(...LIT_SLATE_900);
-    let cy = y + 16;
-    for (const line of wrapped) {
-      doc.text(line, MARGIN + 38, cy);
-      cy += 14;
-    }
-    y += cardH + 8;
-    if (y > PAGE_H - 100) break;
-  }
-}
-
-// ─── PAGE 8 · Sources (every web URL cited) ───────────────────────────────
-function drawSourcesPage(doc: jsPDF, report: BriefReport): void {
-  let y = 100;
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(20);
-  doc.setTextColor(...LIT_SLATE_900);
-  doc.text("Sources", MARGIN, y);
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(10);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text("Every web claim above is backed by one of these.", MARGIN, y + 16);
-  y += 50;
-
-  const sources = report.web_sources ?? [];
-  if (!sources.length) {
-    drawPlaceholder(doc, "This brief did not cite any web sources.", y);
-    return;
-  }
-  autoTable(doc, {
-    startY: y,
-    head: [["#", "Source", "Published"]],
-    body: sources.map((s, i) => [
-      String(i + 1),
-      `${s.title ?? s.publisher ?? "Untitled"}\n${s.url ?? ""}`,
-      s.published_at ?? "—",
-    ]),
-    headStyles: { fillColor: LIT_NAVY, textColor: [255, 255, 255], fontStyle: "bold", fontSize: 9 },
-    bodyStyles: { fontSize: 9, textColor: LIT_SLATE_900 },
-    alternateRowStyles: { fillColor: LIT_CYAN_50 },
-    columnStyles: {
-      0: { halign: "center", cellWidth: 30 },
-      2: { halign: "right", cellWidth: 80 },
-    },
-    margin: { left: MARGIN, right: MARGIN },
-    theme: "striped",
-    styles: { lineColor: LIT_SLATE_200, lineWidth: 0.3 },
-  });
-}
-
-// ─── Header + footer on every page after cover ────────────────────────────
-function stampHeaderAndFooter(doc: jsPDF, companyName: string): void {
-  const pages = doc.getNumberOfPages();
-  for (let i = 2; i <= pages; i++) {
-    doc.setPage(i);
-    // Top header strip — thin navy ribbon w/ mark
-    doc.setFillColor(...LIT_NAVY);
-    doc.rect(0, 0, PAGE_W, 36, "F");
-    doc.setDrawColor(...LIT_CYAN_NEON);
-    doc.setLineWidth(0.6);
-    doc.line(0, 36, PAGE_W, 36);
-    drawPulseLogo(doc, MARGIN, 7, 22);
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(9);
-    doc.setTextColor(...LIT_CYAN_NEON);
-    doc.text("LIT  ·  EXECUTIVE BRIEF", MARGIN + 30, 22);
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(9);
-    doc.setTextColor(...LIT_SLATE_400);
-    doc.text(companyName, PAGE_W - MARGIN, 22, { align: "right" });
-  }
-  // Footer on EVERY page (including cover)
-  for (let i = 1; i <= pages; i++) {
-    doc.setPage(i);
-    if (i > 1) {
-      // Pages 2+: simple footer
-      doc.setFillColor(...LIT_NAVY);
-      doc.rect(0, PAGE_H - FOOTER_H, PAGE_W, FOOTER_H, "F");
-      doc.setDrawColor(...LIT_CYAN_NEON);
-      doc.setLineWidth(0.6);
-      doc.line(0, PAGE_H - FOOTER_H, PAGE_W, PAGE_H - FOOTER_H);
-      doc.setFont("helvetica", "bold");
-      doc.setFontSize(8);
-      doc.setTextColor(255, 255, 255);
-      doc.text("LIT  ·  PULSE EXECUTIVE BRIEF", MARGIN, PAGE_H - FOOTER_H + 17);
-      doc.setFont("helvetica", "normal");
-      doc.setTextColor(...LIT_CYAN_NEON);
-      doc.text(`Page ${i} of ${pages}`, PAGE_W - MARGIN, PAGE_H - FOOTER_H + 17, { align: "right" });
-    }
-  }
-}
-
-// ─── Small drawing helpers ────────────────────────────────────────────────
-function drawSection(doc: jsPDF, label: string, color: [number, number, number], y: number): number {
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(10);
-  doc.setTextColor(...color);
-  doc.text(label, MARGIN, y);
-  doc.setDrawColor(...color);
-  doc.setLineWidth(1.2);
-  doc.line(MARGIN, y + 4, MARGIN + 50, y + 4);
-  return y + 22;
-}
-
-// Strip markdown citation syntax that the LLM emits inline
-// (e.g. "([gapinc.com](https://gapinc.com/...?utm_source=openai))" →
-// removed entirely from prose). Sources still render on the dedicated
-// Sources page, so removing the inline noise just makes the prose
-// readable. Also strips bold/italic asterisks and bare markdown links.
-function stripMarkdown(text: string): string {
-  return text
-    // Parenthesized citation: ([label](url))
-    .replace(/\(\[[^\]]+\]\([^)]+\)\)/g, "")
-    // Bare markdown link: [label](url) → label
+// ─── Markdown sanitiser ───────────────────────────────────────────────────
+function stripMarkdown(text: unknown): string {
+  if (text == null) return "";
+  return String(text)
+    .replace(/\(\[([^\]]+)\]\([^)]+\)\)/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    // Bold / italic
-    .replace(/\*\*(.+?)\*\*/g, "$1")
-    .replace(/\*(.+?)\*/g, "$1")
-    // Collapse double-spaces and trim
-    .replace(/\s{2,}/g, " ")
-    .replace(/\s+\./g, ".")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\s+/g, " ")
     .trim();
 }
 
-function drawParagraph(doc: jsPDF, text: string, y: number): number {
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(11);
-  doc.setTextColor(...LIT_SLATE_900);
-  const clean = stripMarkdown(text);
-  const lines = doc.splitTextToSize(clean, CONTENT_W);
-  for (const line of lines) {
-    if (y > PAGE_H - 80) { doc.addPage(); y = 100; }
-    doc.text(line, MARGIN, y);
-    y += 14;
+// ─── Marketing / creative / PR title filter ───────────────────────────────
+const REJECTED_TITLE_FRAGMENTS = [
+  "marketing", "brand", "creative", "design", "communications",
+  "public relations", "press", "media", "content", "publicist",
+  "sales", "account executive", "business development",
+];
+
+function isLogisticsLeadershipTitle(title: unknown): boolean {
+  if (!title) return false;
+  const t = String(title).toLowerCase();
+  for (const bad of REJECTED_TITLE_FRAGMENTS) {
+    if (t.includes(bad)) return false;
   }
-  return y;
+  return true;
 }
 
-function drawChipList(
+// ─── Pulse mark — light-mode version ──────────────────────────────────────
+function drawPulseLogo(doc: jsPDF, x: number, y: number, size: number): void {
+  const s = size / 64;
+  doc.setFillColor(...INK_900);
+  doc.roundedRect(x, y, size, size, size * 0.22, size * 0.22, "F");
+  doc.setDrawColor(255, 255, 255);
+  doc.setLineWidth(s * 4.4);
+  doc.setLineCap("round");
+  doc.setLineJoin("round");
+  const pts: Array<[number, number]> = [
+    [8, 32], [20, 32], [26, 22], [32, 42], [38, 32], [56, 32],
+  ];
+  for (let i = 1; i < pts.length; i++) {
+    doc.line(x + pts[i - 1][0] * s, y + pts[i - 1][1] * s, x + pts[i][0] * s, y + pts[i][1] * s);
+  }
+  doc.setFillColor(255, 255, 255);
+  doc.circle(x + 56 * s, y + 32 * s, 3 * s, "F");
+}
+
+// ─── Pill rendering helpers ───────────────────────────────────────────────
+function pillColorsForStatus(status: string): { bg: [number, number, number]; fg: [number, number, number] } {
+  const s = (status || "").toLowerCase();
+  if (s.includes("high volume") || s.includes("stable")) return { bg: STATUS_OK_BG, fg: STATUS_OK_FG };
+  if (s.includes("congestion") || s.includes("warning") || s.includes("warn")) return { bg: STATUS_WARN_BG, fg: STATUS_WARN_FG };
+  if (s.includes("grow")) return { bg: STATUS_GROWING_BG, fg: STATUS_GROWING_FG };
+  if (s.includes("declin")) return { bg: STATUS_DECLINING_BG, fg: STATUS_DECLINING_FG };
+  return { bg: STATUS_NEUTRAL_BG, fg: STATUS_NEUTRAL_FG };
+}
+
+function drawPill(
   doc: jsPDF,
-  items: string[],
-  color: [number, number, number],
+  x: number,
   y: number,
+  label: string,
+  bg: [number, number, number],
+  fg: [number, number, number],
+  opts: { fontSize?: number; padX?: number; padY?: number } = {},
+): { w: number; h: number } {
+  const fontSize = opts.fontSize ?? 8.5;
+  const padX = opts.padX ?? 8;
+  const padY = opts.padY ?? 4;
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(fontSize);
+  const textW = doc.getTextWidth(label);
+  const w = textW + padX * 2;
+  const h = fontSize + padY * 2;
+  doc.setFillColor(...bg);
+  doc.roundedRect(x, y, w, h, h / 2, h / 2, "F");
+  doc.setTextColor(...fg);
+  doc.text(label, x + padX, y + padY + fontSize - 2);
+  return { w, h };
+}
+
+function drawPendingPill(doc: jsPDF, x: number, y: number): { w: number; h: number } {
+  return drawPill(doc, x, y, PENDING_TEXT, PENDING_BG, PENDING_FG);
+}
+
+// ─── Section header (uppercase tracked label with light divider) ─────────
+function drawSectionHeader(doc: jsPDF, label: string, y: number, opts: { icon?: string } = {}): number {
+  const iconBoxSize = 16;
+  let x = MARGIN;
+  if (opts.icon) {
+    doc.setFillColor(...INK_900);
+    doc.roundedRect(x, y - iconBoxSize + 4, iconBoxSize, iconBoxSize, 3, 3, "F");
+    doc.setTextColor(255, 255, 255);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(9);
+    const iconW = doc.getTextWidth(opts.icon);
+    doc.text(opts.icon, x + (iconBoxSize - iconW) / 2, y - 1);
+    x += iconBoxSize + 8;
+  }
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10);
+  doc.setTextColor(...INK_900);
+  // Letter-spaced uppercase — approximate by inserting hair spaces.
+  doc.text(label.toUpperCase(), x, y);
+  // Hairline divider under the label.
+  doc.setDrawColor(...INK_200);
+  doc.setLineWidth(0.5);
+  doc.line(MARGIN, y + 6, PAGE_W - MARGIN, y + 6);
+  return y + 22;
+}
+
+// ─── Page chrome ──────────────────────────────────────────────────────────
+function drawHeaderBar(doc: jsPDF): void {
+  // Pure white bar with a hairline rule at the bottom.
+  doc.setFillColor(...WHITE);
+  doc.rect(0, 0, PAGE_W, HEADER_H, "F");
+  doc.setDrawColor(...INK_200);
+  doc.setLineWidth(0.5);
+  doc.line(0, HEADER_H, PAGE_W, HEADER_H);
+  drawPulseLogo(doc, MARGIN, 14, 28);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10);
+  doc.setTextColor(...INK_900);
+  doc.text("LIT PULSE", MARGIN + 36, 28);
+  doc.setFont("helvetica", "normal");
+  doc.setTextColor(...INK_500);
+  doc.setFontSize(9);
+  doc.text("|  EXECUTIVE ACCOUNT BRIEF", MARGIN + 76, 28);
+}
+
+function drawHeaderFreshnessBadge(doc: jsPDF, label: string): void {
+  // Top-right metadata badge — dark pill so it reads as enterprise meta.
+  const text = label || PENDING_TEXT;
+  const bg: [number, number, number] = label ? INK_900 : PENDING_BG;
+  const fg: [number, number, number] = label ? [255, 255, 255] : PENDING_FG;
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8);
+  const w = doc.getTextWidth(text) + 16;
+  const h = 18;
+  const x = PAGE_W - MARGIN - w;
+  const y = (HEADER_H - h) / 2;
+  doc.setFillColor(...bg);
+  doc.roundedRect(x, y, w, h, h / 2, h / 2, "F");
+  doc.setTextColor(...fg);
+  doc.text(text, x + 8, y + h - 6);
+  // Small "DATA FRESHNESS" label above the badge.
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(6.5);
+  doc.setTextColor(...INK_500);
+  const labelText = "DATA FRESHNESS";
+  const lw = doc.getTextWidth(labelText);
+  doc.text(labelText, x + w - lw, y - 3);
+}
+
+function drawFooter(doc: jsPDF, pageNum: number, pageCount: number): void {
+  const y = PAGE_H - FOOTER_H;
+  doc.setDrawColor(...INK_200);
+  doc.setLineWidth(0.5);
+  doc.line(MARGIN, y, PAGE_W - MARGIN, y);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7.5);
+  doc.setTextColor(...INK_500);
+  doc.text("CONFIDENTIAL // FOR INTERNAL STRATEGIC USE", MARGIN, y + 14);
+  const right = `Page ${pageNum} of ${pageCount}`;
+  const rw = doc.getTextWidth(right);
+  doc.text(right, PAGE_W - MARGIN - rw, y + 14);
+}
+
+function stampPageChrome(doc: jsPDF, freshnessLabel: string): void {
+  const total = doc.getNumberOfPages();
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    drawHeaderBar(doc);
+    if (i === 1) drawHeaderFreshnessBadge(doc, freshnessLabel);
+    drawFooter(doc, i, total);
+  }
+}
+
+// ─── Title block ──────────────────────────────────────────────────────────
+function drawTitleBlock(
+  doc: jsPDF,
+  args: ExportArgs,
+  ov: ExecutiveOverview,
+  startY: number,
 ): number {
-  for (const item of items) {
-    if (y > PAGE_H - 80) { doc.addPage(); y = 100; }
-    // Dot bullet
-    doc.setFillColor(...color);
-    doc.circle(MARGIN + 3, y - 3, 2, "F");
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(10.5);
-    doc.setTextColor(...LIT_SLATE_900);
-    const wrapped = doc.splitTextToSize(stripMarkdown(item), CONTENT_W - 16);
-    for (let i = 0; i < wrapped.length; i++) {
-      doc.text(wrapped[i], MARGIN + 14, y);
-      y += 13;
+  let y = startY;
+  const metadata = ov.corporate_metadata ?? {};
+  const parent = stripMarkdown(metadata.parent_company);
+  const companyName = stripMarkdown(args.companyName) || "Untitled Account";
+  const title = parent && parent.toLowerCase() !== companyName.toLowerCase()
+    ? `${companyName.toUpperCase()} (${parent.toUpperCase()})`
+    : companyName.toUpperCase();
+
+  // Report date sub-line.
+  const generated = args.generatedAt ?? new Date();
+  const dateStr = generated.toLocaleDateString("en-US", {
+    year: "numeric", month: "long", day: "numeric",
+  }).toUpperCase();
+
+  // Company headline.
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(20);
+  doc.setTextColor(...INK_900);
+  const titleLines = doc.splitTextToSize(title, CONTENT_W - 110);
+  for (const line of titleLines) {
+    doc.text(line, MARGIN, y);
+    y += 22;
+  }
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8.5);
+  doc.setTextColor(...INK_500);
+  doc.text(`REPORT DATE: ${dateStr}`, MARGIN, y);
+  y += 14;
+
+  // Opportunity index card — top right of the title block.
+  drawOpportunityIndex(doc, ov, startY);
+
+  return y + 6;
+}
+
+function drawOpportunityIndex(doc: jsPDF, ov: ExecutiveOverview, anchorY: number): void {
+  const grade = (ov.opportunity_grade_letter ?? "").toUpperCase();
+  const score = Number.isFinite(ov.opportunity_score_0_to_100) ? Math.round(ov.opportunity_score_0_to_100 as number) : null;
+  const gradeFg = GRADE_FG[grade] ?? INK_500;
+  const w = 96;
+  const h = 64;
+  const x = PAGE_W - MARGIN - w;
+  const y = anchorY - 16;
+  doc.setDrawColor(...INK_200);
+  doc.setFillColor(...WHITE);
+  doc.setLineWidth(0.6);
+  doc.roundedRect(x, y, w, h, 6, 6, "FD");
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...INK_500);
+  doc.text("OPPORTUNITY", x + 10, y + 13);
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(28);
+  doc.setTextColor(...gradeFg);
+  const letter = grade || "—";
+  doc.text(letter, x + 10, y + 44);
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10);
+  doc.setTextColor(...INK_700);
+  const scoreStr = score != null ? `${score} / 100` : PENDING_TEXT;
+  const scoreW = doc.getTextWidth(scoreStr);
+  doc.text(scoreStr, x + w - 10 - scoreW, y + 44);
+
+  // Sub-meta row at the bottom of the card.
+  doc.setDrawColor(...INK_100);
+  doc.setLineWidth(0.5);
+  doc.line(x + 10, y + 50, x + w - 10, y + 50);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7);
+  doc.setTextColor(...INK_500);
+  doc.text("ACCOUNT INDEX", x + 10, y + 60);
+}
+
+// ─── Corporate metadata sub-header ────────────────────────────────────────
+function drawCorporateSubHeader(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  const metadata = ov.corporate_metadata ?? {};
+  const cells: Array<[string, string]> = [
+    ["NAICS SECTOR", stripMarkdown(metadata.naics_sector) || PENDING_TEXT],
+    ["CORPORATE HQ", stripMarkdown(metadata.headquarters_location) || PENDING_TEXT],
+    ["PRIMARY PORT GATEWAY", stripMarkdown(metadata.primary_port_gateway) || PENDING_TEXT],
+  ];
+  const cellW = (CONTENT_W - 110) / cells.length;
+  let x = MARGIN;
+  const y = startY;
+  for (const [label, value] of cells) {
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7);
+    doc.setTextColor(...INK_500);
+    doc.text(label, x, y);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(9);
+    doc.setTextColor(...INK_800);
+    const valueLines = doc.splitTextToSize(value, cellW - 14);
+    doc.text(valueLines[0] ?? "—", x, y + 14);
+    x += cellW;
+  }
+  return y + 28;
+}
+
+// ─── Section 2: Executive macro briefing ──────────────────────────────────
+function drawMacroBriefing(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  let y = drawSectionHeader(doc, "Executive Macro Briefing", startY, { icon: "!" });
+  const briefing = stripMarkdown(ov.executive_macro_briefing);
+  if (!briefing) {
+    drawPendingPill(doc, MARGIN, y);
+    return y + 28;
+  }
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(9.5);
+  doc.setTextColor(...INK_800);
+  const lines = doc.splitTextToSize(briefing, CONTENT_W);
+  for (const line of lines) {
+    doc.text(line, MARGIN, y);
+    y += 13;
+  }
+  return y + 8;
+}
+
+// ─── Section 3: Sourcing demand & logistics volumetrics ───────────────────
+function drawVolumetricsGrid(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  const vol = ov.logistics_volumetrics ?? {};
+  const teu = stripMarkdown(vol.annual_teu_estimate);
+  const tier = stripMarkdown(vol.importer_tier);
+  const lanesCount = Number.isFinite(vol.active_freight_lanes_count) ? String(vol.active_freight_lanes_count) : "";
+  const carriers = Array.isArray(vol.primary_carriers) ? vol.primary_carriers.map((c) => stripMarkdown(c)).filter(Boolean) : [];
+
+  let y = drawSectionHeader(doc, "Sourcing Demand & Logistics Volumetrics", startY);
+
+  const cellW = CONTENT_W / 3;
+  const cellH = 70;
+  const cells: Array<{ label: string; primary: string; subline: string }> = [
+    {
+      label: "EST. ANNUAL TEU",
+      primary: teu || PENDING_TEXT,
+      subline: tier || "Tier classification pending",
+    },
+    {
+      label: "ACTIVE LOGISTICS LANES",
+      primary: lanesCount || PENDING_TEXT,
+      subline: lanesCount ? "Distinct origin → destination corridors" : "",
+    },
+    {
+      label: "PRIMARY OCEAN CARRIERS",
+      primary: carriers[0] || PENDING_TEXT,
+      subline: carriers.length > 1 ? carriers.slice(1, 5).join(" · ") : "",
+    },
+  ];
+
+  for (let i = 0; i < cells.length; i++) {
+    const x = MARGIN + i * cellW + 4;
+    const w = cellW - 8;
+    const c = cells[i];
+    doc.setDrawColor(...INK_200);
+    doc.setFillColor(...WHITE);
+    doc.setLineWidth(0.6);
+    doc.roundedRect(x, y, w, cellH, 6, 6, "FD");
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7);
+    doc.setTextColor(...INK_500);
+    doc.text(c.label, x + 10, y + 16);
+    // Primary value — large.
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(c.primary === PENDING_TEXT ? 10 : 18);
+    doc.setTextColor(c.primary === PENDING_TEXT ? PENDING_FG[0] : INK_900[0], c.primary === PENDING_TEXT ? PENDING_FG[1] : INK_900[1], c.primary === PENDING_TEXT ? PENDING_FG[2] : INK_900[2]);
+    const primaryLines = doc.splitTextToSize(c.primary, w - 20);
+    doc.text(primaryLines[0] ?? "—", x + 10, y + 40);
+    // Sub-line.
+    if (c.subline) {
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(8);
+      doc.setTextColor(...INK_500);
+      const subLines = doc.splitTextToSize(c.subline, w - 20);
+      doc.text(subLines.slice(0, 2), x + 10, y + 56);
     }
-    y += 4;
+  }
+  return y + cellH + 14;
+}
+
+function drawTradeLanesTable(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  let y = drawSectionHeader(doc, "Critical Trade Lane Velocity (Top 3)", startY);
+  const lanes = Array.isArray(ov.trade_lane_velocity) ? ov.trade_lane_velocity : [];
+  if (!lanes.length) {
+    drawPendingPill(doc, MARGIN, y);
+    return y + 28;
+  }
+
+  const head: RowInput = [
+    [
+      { content: "Port Pair / Route", styles: { halign: "left" } },
+      { content: "Volume Share", styles: { halign: "right" } },
+      { content: "Est. Ocean Transit", styles: { halign: "right" } },
+      { content: "Velocity Status", styles: { halign: "center" } },
+    ],
+  ];
+  const body: RowInput[] = lanes.slice(0, 3).map((row, i) => [
+    {
+      content: stripMarkdown(row.route) || `Lane ${i + 1}`,
+      styles: { halign: "left" },
+    },
+    {
+      content: Number.isFinite(row.volume_share_pct) ? `${row.volume_share_pct}%` : "—",
+      styles: { halign: "right" },
+    },
+    {
+      content: Number.isFinite(row.transit_days) ? `${row.transit_days} days` : "—",
+      styles: { halign: "right" },
+    },
+    {
+      content: stripMarkdown(row.velocity_status) || "Moderate",
+      styles: { halign: "center" },
+    },
+  ]);
+
+  autoTable(doc, {
+    head,
+    body,
+    startY: y,
+    margin: { left: MARGIN, right: MARGIN },
+    theme: "grid",
+    styles: {
+      font: "helvetica",
+      fontSize: 9,
+      textColor: INK_800,
+      lineColor: INK_200,
+      lineWidth: 0.5,
+      cellPadding: 6,
+    },
+    headStyles: {
+      fillColor: INK_50,
+      textColor: INK_700,
+      fontStyle: "bold",
+      fontSize: 8,
+      lineColor: INK_200,
+      lineWidth: 0.5,
+    },
+    bodyStyles: {
+      fillColor: WHITE,
+    },
+    alternateRowStyles: {
+      fillColor: INK_50,
+    },
+    didDrawCell: (data) => {
+      // Status column — render the value as a pill instead of plain text.
+      if (data.section === "body" && data.column.index === 3) {
+        const status = String(data.cell.raw && (data.cell.raw as any).content || "Moderate");
+        const colors = pillColorsForStatus(status);
+        // Clear the underlying text by painting a white rect.
+        doc.setFillColor(...WHITE);
+        doc.rect(data.cell.x + 1, data.cell.y + 1, data.cell.width - 2, data.cell.height - 2, "F");
+        const cx = data.cell.x + data.cell.width / 2;
+        const cy = data.cell.y + data.cell.height / 2 - 6;
+        doc.setFont("helvetica", "bold");
+        doc.setFontSize(8);
+        const tw = doc.getTextWidth(status);
+        const pw = tw + 16;
+        const ph = 14;
+        doc.setFillColor(...colors.bg);
+        doc.roundedRect(cx - pw / 2, cy, pw, ph, ph / 2, ph / 2, "F");
+        doc.setTextColor(...colors.fg);
+        doc.text(status, cx - tw / 2, cy + ph - 4);
+      }
+    },
+  });
+  // @ts-expect-error jspdf-autotable mutates the doc.
+  return doc.lastAutoTable.finalY + 12;
+}
+
+// ─── Section 4: Friction points & value hypotheses ────────────────────────
+function drawFrictionPoints(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  let y = drawSectionHeader(doc, "Metric-Based Friction Points & Value Hypotheses", startY, { icon: "x" });
+  const items = Array.isArray(ov.friction_points) ? ov.friction_points : [];
+  if (!items.length) {
+    drawPendingPill(doc, MARGIN, y);
+    return y + 28;
+  }
+
+  const head: RowInput = [
+    [
+      { content: "Identified Supply Chain Stressor", styles: { halign: "left" } },
+      { content: "LIT Platform Value Hypothesis", styles: { halign: "left" } },
+    ],
+  ];
+  const body: RowInput[] = items.map((p) => [
+    stripMarkdown(p.stressor) || PENDING_TEXT,
+    stripMarkdown(p.value_hypothesis) || PENDING_TEXT,
+  ]);
+
+  autoTable(doc, {
+    head,
+    body,
+    startY: y,
+    margin: { left: MARGIN, right: MARGIN },
+    theme: "grid",
+    styles: {
+      font: "helvetica",
+      fontSize: 9,
+      textColor: INK_800,
+      lineColor: INK_200,
+      lineWidth: 0.5,
+      cellPadding: 8,
+      valign: "top",
+    },
+    headStyles: {
+      fillColor: INK_50,
+      textColor: INK_700,
+      fontStyle: "bold",
+      fontSize: 8,
+      lineColor: INK_200,
+      lineWidth: 0.5,
+    },
+    bodyStyles: { fillColor: WHITE },
+    alternateRowStyles: { fillColor: INK_50 },
+    columnStyles: {
+      0: { cellWidth: CONTENT_W * 0.5 },
+      1: { cellWidth: CONTENT_W * 0.5 },
+    },
+  });
+  // @ts-expect-error jspdf-autotable mutates the doc.
+  return doc.lastAutoTable.finalY + 12;
+}
+
+// ─── Section 5: Supply chain leadership ───────────────────────────────────
+function drawLeadership(doc: jsPDF, ov: ExecutiveOverview, startY: number): number {
+  let y = drawSectionHeader(doc, "Supply Chain Leadership Enrichment", startY, { icon: "i" });
+
+  const raw = Array.isArray(ov.supply_chain_leadership) ? ov.supply_chain_leadership : [];
+  // Filter out any non-logistics title that slipped past the LLM.
+  const filtered = raw.filter((c) => isLogisticsLeadershipTitle(c.title)).slice(0, 2);
+
+  if (!filtered.length) {
+    drawPendingPill(doc, MARGIN, y);
+    return y + 28;
+  }
+
+  for (const c of filtered) {
+    const name = stripMarkdown(c.name) || PENDING_TEXT;
+    const title = stripMarkdown(c.title) || PENDING_TEXT;
+    const mandate = stripMarkdown(c.strategic_mandate) || PENDING_TEXT;
+
+    // Bullet marker.
+    doc.setFillColor(...INK_900);
+    doc.circle(MARGIN + 3, y - 3, 2, "F");
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10);
+    doc.setTextColor(...INK_900);
+    doc.text(name, MARGIN + 12, y);
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(...INK_700);
+    const titleText = ` — ${title}`;
+    const nameW = doc.getTextWidth(name);
+    doc.text(titleText, MARGIN + 12 + nameW, y);
+
+    // Mandate one row below.
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(8.5);
+    doc.setTextColor(...INK_500);
+    const mandateLines = doc.splitTextToSize(`Focus: ${mandate}`, CONTENT_W - 14);
+    doc.text(mandateLines.slice(0, 2), MARGIN + 12, y + 12);
+
+    y += 12 + mandateLines.slice(0, 2).length * 11 + 6;
+  }
+  return y + 4;
+}
+
+// ─── Page break helper ────────────────────────────────────────────────────
+function ensureRoom(doc: jsPDF, y: number, needed: number): number {
+  if (y + needed > PAGE_H - FOOTER_H - 16) {
+    doc.addPage();
+    return HEADER_H + 24;
   }
   return y;
 }
 
-function drawPlaceholder(doc: jsPDF, msg: string, y: number): void {
-  doc.setFillColor(...LIT_CYAN_50);
-  doc.setDrawColor(...LIT_CYAN_NEON);
-  doc.setLineWidth(0.4);
-  doc.roundedRect(MARGIN, y, CONTENT_W, 80, 8, 8, "FD");
-  doc.setFont("helvetica", "normal");
-  doc.setFontSize(11);
-  doc.setTextColor(...LIT_SLATE_600);
-  doc.text(msg, MARGIN + 16, y + 44);
+// ─── Public entry point ──────────────────────────────────────────────────
+export function exportPulseExecutivePdf(args: ExportArgs): void {
+  const doc = new jsPDF({ unit: "pt", format: "letter" });
+  doc.setFillColor(...WHITE);
+  doc.rect(0, 0, PAGE_W, PAGE_H, "F");
+
+  const ov: ExecutiveOverview = args.brief?.report?.executive_overview ?? {};
+  const freshnessLabel = stripMarkdown(ov.data_freshness_label) || "REAL-TIME CUSTOMS MANIFEST";
+
+  // Block 1: title + opportunity index + corporate metadata sub-header.
+  let y = HEADER_H + 28;
+  y = drawTitleBlock(doc, args, ov, y);
+  y = drawCorporateSubHeader(doc, ov, y + 4);
+
+  // Block 2: executive macro briefing.
+  y = ensureRoom(doc, y, 90);
+  y = drawMacroBriefing(doc, ov, y + 6);
+
+  // Block 3a: volumetrics grid.
+  y = ensureRoom(doc, y, 110);
+  y = drawVolumetricsGrid(doc, ov, y + 4);
+
+  // Block 3b: trade lane table.
+  y = ensureRoom(doc, y, 120);
+  y = drawTradeLanesTable(doc, ov, y);
+
+  // Block 4: friction points.
+  y = ensureRoom(doc, y, 140);
+  y = drawFrictionPoints(doc, ov, y);
+
+  // Block 5: leadership.
+  y = ensureRoom(doc, y, 120);
+  drawLeadership(doc, ov, y);
+
+  // Stamp consistent header + footer chrome on every page.
+  stampPageChrome(doc, freshnessLabel);
+
+  const slug = (args.companyName || "account")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const generated = args.generatedAt ?? new Date();
+  const dateSlug = generated.toISOString().slice(0, 10);
+  doc.save(`LIT-Executive-Brief-${slug}-${dateSlug}.pdf`);
 }

--- a/supabase/functions/pulse-ai-enrich/index.ts
+++ b/supabase/functions/pulse-ai-enrich/index.ts
@@ -274,27 +274,39 @@ function buildReportSchema() {
         items: { type: "string" },
       },
       // Executive Pre-Call Brief overview — feeds the downloadable PDF
-      // shared with execs. Distinct from the rest of the report (which
-      // is sales-rep-grade); this block is the 30-second "what do I
-      // need to know before I walk into the call" essence.
+      // shared with execs. Studio White redesign 2026-06-18: structured
+      // logistics intelligence, no sales scripts. Every field maps to a
+      // single corporate-blueprint block in the PDF.
       executive_overview: {
         type: "object",
         additionalProperties: false,
         required: [
-          "tldr",
+          "corporate_metadata",
           "opportunity_grade_letter",
           "opportunity_score_0_to_100",
-          "key_metrics_snapshot",
-          "pre_call_talking_points",
-          "likely_objections",
-          "best_contact_and_approach",
+          "data_freshness_label",
+          "executive_macro_briefing",
+          "logistics_volumetrics",
+          "trade_lane_velocity",
+          "friction_points",
+          "supply_chain_leadership",
         ],
         properties: {
-          tldr: {
-            type: "array",
-            items: { type: "string" },
-            minItems: 3,
-            maxItems: 3,
+          corporate_metadata: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "parent_company",
+              "naics_sector",
+              "headquarters_location",
+              "primary_port_gateway",
+            ],
+            properties: {
+              parent_company: { type: "string" },
+              naics_sector: { type: "string" },
+              headquarters_location: { type: "string" },
+              primary_port_gateway: { type: "string" },
+            },
           },
           opportunity_grade_letter: {
             type: "string",
@@ -305,55 +317,75 @@ function buildReportSchema() {
             minimum: 0,
             maximum: 100,
           },
-          key_metrics_snapshot: {
+          data_freshness_label: { type: "string" },
+          executive_macro_briefing: { type: "string" },
+          logistics_volumetrics: {
             type: "object",
             additionalProperties: false,
             required: [
-              "shipments_12m",
-              "teu_12m",
-              "top_lane",
-              "top_carrier",
-              "recent_activity_summary",
-              "freshness_label",
+              "annual_teu_estimate",
+              "importer_tier",
+              "active_freight_lanes_count",
+              "primary_carriers",
             ],
             properties: {
-              shipments_12m: { type: "string" },
-              teu_12m: { type: "string" },
-              top_lane: { type: "string" },
-              top_carrier: { type: "string" },
-              recent_activity_summary: { type: "string" },
-              freshness_label: { type: "string" },
+              annual_teu_estimate: { type: "string" },
+              importer_tier: { type: "string" },
+              active_freight_lanes_count: { type: "number" },
+              primary_carriers: {
+                type: "array",
+                items: { type: "string" },
+                minItems: 1,
+                maxItems: 6,
+              },
             },
           },
-          pre_call_talking_points: {
-            type: "array",
-            items: { type: "string" },
-            minItems: 5,
-            maxItems: 5,
-          },
-          likely_objections: {
+          trade_lane_velocity: {
             type: "array",
             minItems: 3,
             maxItems: 3,
             items: {
               type: "object",
               additionalProperties: false,
-              required: ["objection", "response"],
+              required: ["route", "volume_share_pct", "transit_days", "velocity_status"],
               properties: {
-                objection: { type: "string" },
-                response: { type: "string" },
+                route: { type: "string" },
+                volume_share_pct: { type: "number", minimum: 0, maximum: 100 },
+                transit_days: { type: "number", minimum: 0 },
+                velocity_status: {
+                  type: "string",
+                  enum: ["High Volume / Stable", "Transit Congestion Warning", "Growing", "Stable", "Declining", "Moderate"],
+                },
               },
             },
           },
-          best_contact_and_approach: {
-            type: "object",
-            additionalProperties: false,
-            required: ["contact_name", "contact_title", "channel", "opening_line"],
-            properties: {
-              contact_name: { type: "string" },
-              contact_title: { type: "string" },
-              channel: { type: "string" },
-              opening_line: { type: "string" },
+          friction_points: {
+            type: "array",
+            minItems: 2,
+            maxItems: 4,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["stressor", "value_hypothesis"],
+              properties: {
+                stressor: { type: "string" },
+                value_hypothesis: { type: "string" },
+              },
+            },
+          },
+          supply_chain_leadership: {
+            type: "array",
+            minItems: 2,
+            maxItems: 2,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["name", "title", "strategic_mandate"],
+              properties: {
+                name: { type: "string" },
+                title: { type: "string" },
+                strategic_mandate: { type: "string" },
+              },
             },
           },
         },
@@ -927,16 +959,52 @@ Freight market intelligence rules:
 - Keep tone like a senior account manager talking to another rep — confident, specific, never salesy.
 - Never round below the nearest $10K when the value is over $1M; never invent a number that isn't in lane_matches.
 
-Executive Overview rules (the executive_overview block):
-- This block feeds a PDF executives read in 60 seconds before a discovery call. Be ruthlessly terse and exec-grade.
-- tldr: exactly 3 bullets, each ≤ 15 words. Each bullet must be one actionable insight (not a generic statement).
-- opportunity_grade_letter: A (high-velocity AND high-priority signal), B (strong on one dimension), C (worth a call but not urgent), D (low fit / inactive).
-- opportunity_score_0_to_100: integer score, internally consistent with the letter grade.
-- key_metrics_snapshot: short human-readable strings (e.g. "7,862 / yr", "18.9K", "Turkey → United States", "Hapag-Lloyd", "Last shipment 23 days ago", "Saved · 14d ago").
-- pre_call_talking_points: 5 ranked openers a rep can read off in the first 90 seconds. Lead with the most pointed; each ≤ 20 words.
-- likely_objections: 3 real objections an exec at this company would raise, paired with a crisp 1-sentence response. Avoid generic "we already have a forwarder" — ground each in something specific.
-- best_contact_and_approach: the single best opener — who to call (or LinkedIn), their title, the channel, and the literal first sentence of the message.
-- Every executive_overview claim must be grounded in either LIT verified data, a web_sources citation, or a defensible logistics inference. If you can't, mark missing_data and write less rather than fabricate.
+Executive Overview rules (the executive_overview block) — STUDIO WHITE corporate blueprint:
+
+This block feeds a downloadable executive PDF that is read in 60 seconds before a discovery call. The aesthetic is "Studio White" premium light-mode — ultra-professional, objective, clinical, data-driven. Every output must read like a McKinsey supply-chain memo, NOT like sales prospecting copy.
+
+ABSOLUTE EXCLUSION RULES:
+- NO sales scripts. NO talking points to read off. NO opening lines. NO outreach copy. NO email templates. NO hook lines. NO "Dear Mr/Ms ..." sentences. The PDF MUST NOT contain anything an SDR would paste into a sequence.
+- NO marketing / creative / PR / brand / communications contacts. Only logistics + supply-chain decision-makers with operational P&L ownership.
+- NO non-logistics commentary unless it ties directly to operational margin (e.g. stock pressure → factory-to-shelf velocity is fine; brand collaboration as fashion news is not).
+- NO placeholder filler. When a real value is unknown, return the string "[Enrichment in Progress]" so the PDF renders the pending badge instead of fake data.
+
+corporate_metadata:
+- parent_company: the legal parent if different from the brand name (e.g. "Gap Inc.", "Inditex", "Berkshire Hathaway"). If same as brand, repeat the brand name.
+- naics_sector: NAICS sector / 2-4 digit classification phrased like "Retail — General Merchandise" or "Manufacturing — Motor Vehicles".
+- headquarters_location: corporate HQ "City, State/Country".
+- primary_port_gateway: the single dominant US port-of-entry complex this account flows through (e.g. "Los Angeles / Long Beach", "New York / Newark", "Savannah").
+
+opportunity_grade_letter / opportunity_score_0_to_100: as before. Score is the numeric the PDF renders next to the grade.
+
+data_freshness_label: short pill text, e.g. "Real-Time Customs Manifest Match", "Refreshed 14d ago", "Stale (>180d)".
+
+executive_macro_briefing: a SINGLE dense paragraph (3-5 sentences, 60-120 words) bridging public financial standing — stock pressures, market cap shifts, restructuring, leadership changes — with the internal SUPPLY-CHAIN operational impacts. Frame everything through a logistics lens: how does this affect factory-to-shelf velocity, container volume capacity, transportation margin compression, sourcing diversification, port allocation? Do not narrate marketing campaigns as marketing news; narrate them as freight demand signals.
+
+logistics_volumetrics:
+- annual_teu_estimate: short human-readable string like "~85,000+", "12-18K", "Sub-1K (low-volume importer)". Include rough magnitude only.
+- importer_tier: enterprise tier label, one of: "Tier-1 Macro Importer" (>50K TEU/yr), "Tier-2 Strategic Importer" (10-50K), "Tier-3 Mid-Market Importer" (1-10K), "Tier-4 Specialty / Project Importer" (<1K). Pick based on annual_teu_estimate.
+- active_freight_lanes_count: integer count of currently active origin-destination corridors (BOL-derived).
+- primary_carriers: 1-6 ocean carrier / alliance names ordered by manifest share (e.g. ["ONE", "Cosco", "Maersk", "MSC"]).
+
+trade_lane_velocity: EXACTLY 3 entries — the top three lanes by volume share for this account.
+- route: "Port of origin (CC) → Port of discharge (CC)" format using city + country code, e.g. "Yantian (CN) → Long Beach (US)".
+- volume_share_pct: integer percent of this account's total volume on that lane.
+- transit_days: estimated ocean transit days.
+- velocity_status: one of the enum values. "High Volume / Stable" for primary lanes. "Transit Congestion Warning" if known port congestion or detention risk. "Growing" / "Stable" / "Declining" for trend. "Moderate" as a neutral fallback.
+
+friction_points: 2-4 entries mapping a SPECIFIC, technical supply-chain stressor to a LIT-platform value hypothesis.
+- stressor: a logistics bottleneck. EXAMPLES: "High demurrage and detention risk at Los Angeles / Long Beach terminals due to holiday inventory staging", "Volatile transpacific ocean spot rates impacting product-to-market margins on value-space apparel (<$55 price point)", "Carrier concentration risk — top 2 carriers represent >70% of TEU; no failover lane", "Upstream supplier delays from Yantian-region power rationing extending lead times by 9-14 days". Do NOT use generic phrases like "supply chain disruptions".
+- value_hypothesis: how a SPECIFIC LIT platform feature mitigates THAT stressor. Cite the feature by name where possible: predictive container milestone tracking, FBX-anchored rate benchmarking, lane allocation auditing, secondary-port routing optimisation, carrier diversification scoring, demurrage exposure forecasting. Example: "LIT's predictive container tracking can optimise cargo flow by identifying and routing critical shipments to less congested secondary ports (e.g. Seattle, Vancouver)."
+
+supply_chain_leadership: EXACTLY 2 contacts. Both MUST have direct P&L or operational ownership of the logistics / supply-chain network. Acceptable titles include Chief Supply Chain Officer, Chief Operating Officer, EVP / SVP / VP of Global Logistics, VP of Inventory Management, VP of Transportation, VP of Distribution, VP of Procurement (if logistics-flavored). REJECT marketing, creative, PR, brand, communications, sales, HR, finance (unless explicitly P&L-over-logistics).
+- name: Full name as it appears on LinkedIn or in public filings.
+- title: exact corporate title.
+- strategic_mandate: ONE sentence summarising their operational domain — what part of the network they own (e.g. "Global Sourcing, Logistics Network, Transformation.", "Online Global Inventory Management, E-commerce Logistics.").
+
+GROUNDING: every claim must be backed by LIT verified data, web_sources citation, or a defensible logistics inference. If you cannot ground a field, write "[Enrichment in Progress]" verbatim so the PDF renders the pending badge.
+
+CITATION FORMAT: do not include markdown citation syntax like ([source.com](url)) or [text](url) anywhere in executive_overview field values. The PDF renderer strips it but the strings should not contain it to begin with — the web_sources block carries the citation evidence separately.
 `;
 }
 


### PR DESCRIPTION
Full rewrite of both the LLM schema/prompt (pulse-ai-enrich) and the PDF generator (exportPulseExecutivePdf) to the corporate blueprint the user specified. Discovery call deck for execs — premium light mode, scannable structure, zero SDR copy.

LLM schema (pulse-ai-enrich/index.ts)
- executive_overview block replaced. New required shape: corporate_metadata { parent_company, naics_sector, headquarters_location, primary_port_gateway } · data_freshness_label · executive_macro_briefing (single dense paragraph, 60-120 words) · logistics_volumetrics { annual_teu_estimate, importer_tier, active_freight_lanes_count, primary_carriers[] } · trade_lane_velocity[3] { route, volume_share_pct, transit_days, velocity_status enum } · friction_points[2-4] { stressor, value_hypothesis } · supply_chain_leadership[2] { name, title, strategic_mandate }.
- tldr / pre_call_talking_points / likely_objections / best_contact_and_approach REMOVED — every sales-script field is gone from the schema. The PDF can no longer surface SDR copy because the LLM is not asked to generate it.
- Prompt rules rewritten with hard exclusions: no sales scripts, no opening lines, no email templates, no marketing / brand / PR / creative contacts, missing values must return "[Enrichment in Progress]" verbatim so the renderer shows the pending badge.
- Importer tier picked from a fixed 4-band ladder so the metric grid reads consistently across accounts.

PDF generator (frontend/src/lib/pulse/exportPulseExecutivePdf.ts)
- File rewritten end-to-end. Old navy/cyan dark theme retired. New Studio White palette: pure-white surfaces, near-black headlines, hairline #E2E8F0 borders, dark-pill metadata badges, status pills on the trade-lane table.
- Four-part corporate blueprint with dense layout — content fits on 1-2 pages depending on text length, not 8 like the prior version.
- drawSectionHeader uses uppercase tracking + a 16pt dark icon badge ([!], [x], [i]) matching the user-supplied sample image.
- Volumetrics grid is a 3-card row (TEU + tier, lanes count, primary carriers). Trade lane table uses jspdf-autotable with hairline borders + alternating zebra; the velocity column repaints each cell as a pill via didDrawCell.
- Friction points table is a 50/50 two-column grid (stressor → hypothesis) — hairline, no shading beyond the zebra.
- Leadership section runs `isLogisticsLeadershipTitle()` over every contact before render — any title containing marketing / brand / creative / PR / communications / sales / BD is filtered out regardless of what the LLM returned. Belt + suspenders against LLM drift.
- Every block independently checks its source field; when missing, renders a `[Enrichment in Progress]` pill instead of placeholder text. Old cached briefs (pre-redesign) gracefully degrade to pending badges rather than crashing.
- stripMarkdown still wraps every prose path so any leaked LLM citation markdown can't render literally in the PDF.

Caller signature unchanged — CompanyProfileV2.handleExportPdfClick keeps working without any changes on the page side.