### PR TITLE
fix(pulse): force edge-fn redeploy + PDF backwards-compat + status pi…

### DIFF
--- a/frontend/src/lib/pulse/exportPulseExecutivePdf.ts
+++ b/frontend/src/lib/pulse/exportPulseExecutivePdf.ts
@@ -132,9 +132,12 @@ interface ExecutiveOverview {
   friction_points?: FrictionPoint[];
   supply_chain_leadership?: LeadershipContact[];
 
-  // Legacy fields — read with permissive fallback so a cached
-  // pre-redesign brief still renders a partial Studio White PDF
-  // instead of crashing. Never rendered as sales copy.
+  // Pre-2026-06-18 legacy fields, kept so the backwards-compat layer
+  // below can synthesise new-shape blocks from cached briefs that still
+  // carry the old schema (tldr / pre_call_talking_points / etc).
+  // Without this layer, every pre-redesign cached brief renders as an
+  // all-Enrichment-in-Progress skeleton until the user manually
+  // refreshes it.
   key_metrics_snapshot?: {
     shipments_12m?: string;
     teu_12m?: string;
@@ -143,11 +146,25 @@ interface ExecutiveOverview {
     recent_activity_summary?: string;
     freshness_label?: string;
   };
+  tldr?: string[];
 }
 
 interface BriefReport {
   company_summary?: string;
   why_now?: string;
+  sales_angle?: string;
+  lane_insights?: string[];
+  carrier_opportunities?: string[];
+  risk_flags?: string[];
+  forwarder_displacement_opportunities?: string[];
+  buying_signals?: string[];
+  supplier_insights?: string[];
+  recommended_contacts?: Array<{
+    name?: string;
+    title?: string;
+    reason?: string;
+    confidence?: number;
+  }>;
   executive_overview?: ExecutiveOverview;
 }
 
@@ -186,6 +203,136 @@ function isLogisticsLeadershipTitle(title: unknown): boolean {
     if (t.includes(bad)) return false;
   }
   return true;
+}
+
+// ─── Backwards-compat: synthesise new-shape blocks from old-shape ────────
+// Cached briefs from before the 2026-06-18 schema redesign still have
+// the legacy executive_overview { tldr, pre_call_talking_points, ... }
+// shape PLUS top-level fields (lane_insights, carrier_opportunities,
+// risk_flags, recommended_contacts). Without this layer, the new PDF
+// reads only the new field names and renders every section as an
+// [Enrichment in Progress] pill — which is what the user reported as
+// "looks even worst than before." This layer maps the legacy data
+// into the new shape so the PDF renders REAL data during the cache
+// transition. New-shape briefs short-circuit on line 1.
+function buildExecutiveOverviewWithFallback(
+  args: ExportArgs,
+  report: BriefReport | undefined,
+): ExecutiveOverview {
+  const newShape = report?.executive_overview ?? {};
+
+  // New-shape brief — return as-is. Detected by presence of any
+  // Studio White block that the old schema does not emit.
+  const isNewShape = !!(
+    newShape.corporate_metadata ||
+    newShape.executive_macro_briefing ||
+    newShape.logistics_volumetrics ||
+    newShape.trade_lane_velocity ||
+    newShape.friction_points ||
+    newShape.supply_chain_leadership
+  );
+  if (isNewShape) return newShape;
+
+  // Old-shape brief — synthesise the new blocks from legacy fields.
+  // Every block is independently null-checked; if there's no signal
+  // in the cached brief, the corresponding section still renders a
+  // pending pill (not fabricated data).
+  const synth: ExecutiveOverview = {
+    opportunity_grade_letter: newShape.opportunity_grade_letter,
+    opportunity_score_0_to_100: newShape.opportunity_score_0_to_100,
+    data_freshness_label:
+      stripMarkdown(newShape.key_metrics_snapshot?.freshness_label) || undefined,
+  };
+
+  // corporate_metadata: derived from the export args + the company's
+  // public industry tag. The args carry the canonical company name.
+  synth.corporate_metadata = {
+    parent_company: stripMarkdown(args.companyName) || undefined,
+    naics_sector: stripMarkdown(args.industry) || undefined,
+    headquarters_location: stripMarkdown(args.hq) || undefined,
+    primary_port_gateway: undefined,
+  };
+
+  // executive_macro_briefing: join company_summary + why_now into one
+  // dense paragraph. These are the legacy prose fields and reading
+  // them through stripMarkdown keeps the strict no-markdown rule.
+  const summary = stripMarkdown(report?.company_summary);
+  const whyNow = stripMarkdown(report?.why_now);
+  const briefingParts = [summary, whyNow].filter(Boolean);
+  if (briefingParts.length) {
+    synth.executive_macro_briefing = briefingParts.join(" ").slice(0, 800);
+  }
+
+  // logistics_volumetrics: read from old key_metrics_snapshot when
+  // present, else from carrier_opportunities (length of array ≈
+  // active corridors) and lane_insights.
+  const snap = newShape.key_metrics_snapshot;
+  const laneInsights = Array.isArray(report?.lane_insights) ? report!.lane_insights : [];
+  const carrierOps = Array.isArray(report?.carrier_opportunities) ? report!.carrier_opportunities : [];
+  if (snap || laneInsights.length || carrierOps.length) {
+    synth.logistics_volumetrics = {
+      annual_teu_estimate: stripMarkdown(snap?.teu_12m) || undefined,
+      importer_tier: undefined,
+      active_freight_lanes_count: laneInsights.length || undefined,
+      primary_carriers: carrierOps
+        .slice(0, 4)
+        .map((c) => stripMarkdown(c).split(/[—:|]/)[0].trim())
+        .filter(Boolean),
+    };
+  }
+
+  // trade_lane_velocity: map lane_insights into the 3-row table.
+  // Velocity status defaults to Moderate because the legacy schema
+  // didn't carry an explicit velocity flag.
+  if (laneInsights.length) {
+    synth.trade_lane_velocity = laneInsights.slice(0, 3).map((insight) => {
+      const cleaned = stripMarkdown(insight);
+      return {
+        route: cleaned.split(/[—:.]/)[0].trim().slice(0, 60) || cleaned.slice(0, 60),
+        volume_share_pct: undefined,
+        transit_days: undefined,
+        velocity_status: "Moderate",
+      };
+    });
+  }
+
+  // friction_points: pair risk_flags (stressors) with carrier_
+  // opportunities and forwarder_displacement_opportunities (LIT
+  // value hypotheses). Cap at 4 to match the new schema.
+  const stressors = Array.isArray(report?.risk_flags) ? report!.risk_flags : [];
+  const hypotheses = [
+    ...(Array.isArray(report?.carrier_opportunities) ? report!.carrier_opportunities : []),
+    ...(Array.isArray(report?.forwarder_displacement_opportunities)
+      ? report!.forwarder_displacement_opportunities
+      : []),
+  ];
+  if (stressors.length || hypotheses.length) {
+    const rows = Math.max(2, Math.min(4, Math.max(stressors.length, hypotheses.length)));
+    const friction: FrictionPoint[] = [];
+    for (let i = 0; i < rows; i++) {
+      friction.push({
+        stressor: stripMarkdown(stressors[i]) || undefined,
+        value_hypothesis: stripMarkdown(hypotheses[i]) || undefined,
+      });
+    }
+    synth.friction_points = friction;
+  }
+
+  // supply_chain_leadership: filter recommended_contacts through the
+  // same logistics-title gate the new renderer uses, take top 2.
+  const contacts = Array.isArray(report?.recommended_contacts) ? report!.recommended_contacts : [];
+  const logisticsContacts = contacts
+    .filter((c) => isLogisticsLeadershipTitle(c.title))
+    .slice(0, 2);
+  if (logisticsContacts.length) {
+    synth.supply_chain_leadership = logisticsContacts.map((c) => ({
+      name: stripMarkdown(c.name) || undefined,
+      title: stripMarkdown(c.title) || undefined,
+      strategic_mandate: stripMarkdown(c.reason) || undefined,
+    }));
+  }
+
+  return synth;
 }
 
 // ─── Pulse mark — branded waveform on dark tile ──────────────────────────
@@ -522,6 +669,7 @@ function drawVolumetricsGrid(doc: jsPDF, ov: ExecutiveOverview, startY: number):
     const x = MARGIN + i * cellW + 4;
     const w = cellW - 8;
     const c = cells[i];
+    const isPending = c.primary === PENDING_TEXT;
     doc.setDrawColor(...INK_200);
     doc.setFillColor(...WHITE);
     doc.setLineWidth(0.6);
@@ -530,14 +678,26 @@ function drawVolumetricsGrid(doc: jsPDF, ov: ExecutiveOverview, startY: number):
     doc.setFontSize(7);
     doc.setTextColor(...INK_500);
     doc.text(c.label, x + 10, y + 16);
-    // Primary value — large.
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(c.primary === PENDING_TEXT ? 10 : 18);
-    doc.setTextColor(c.primary === PENDING_TEXT ? PENDING_FG[0] : INK_900[0], c.primary === PENDING_TEXT ? PENDING_FG[1] : INK_900[1], c.primary === PENDING_TEXT ? PENDING_FG[2] : INK_900[2]);
-    const primaryLines = doc.splitTextToSize(c.primary, w - 20);
-    doc.text(primaryLines[0] ?? "—", x + 10, y + 40);
-    // Sub-line.
-    if (c.subline) {
+
+    if (isPending) {
+      // Render the pending state as the consistent yellow pill used
+      // elsewhere — never as raw text at a different font size. This
+      // is the same component drawPendingPill renders for empty
+      // sections, so the card feels visually intentional, not broken.
+      drawPendingPill(doc, x + 10, y + 30);
+    } else {
+      // Primary metric value — large dark numerals.
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(18);
+      doc.setTextColor(...INK_900);
+      const primaryLines = doc.splitTextToSize(c.primary, w - 20);
+      doc.text(primaryLines[0] ?? "—", x + 10, y + 40);
+    }
+
+    // Sub-line. Skip the auto "Tier classification pending" string
+    // when the primary itself is already a pending pill — would
+    // double up on the empty-state message in a single card.
+    if (c.subline && !(isPending && c.subline.toLowerCase().includes("pending"))) {
       doc.setFont("helvetica", "normal");
       doc.setFontSize(8);
       doc.setTextColor(...INK_500);
@@ -564,6 +724,14 @@ function drawTradeLanesTable(doc: jsPDF, ov: ExecutiveOverview, startY: number):
       { content: "Velocity Status", styles: { halign: "center" } },
     ],
   ];
+  // Hold the status strings in a side array so the velocity column can
+  // render as a pill in didDrawCell WITHOUT autoTable also drawing the
+  // raw text in the cell. Painting white-over-text leaves background
+  // tint mismatches on alternating rows and a hairline of bleed-through
+  // at the cell edge — the bug the user reported as "looks even worst."
+  const velocityStatuses: string[] = lanes.slice(0, 3).map(
+    (row) => stripMarkdown(row.velocity_status) || "Moderate",
+  );
   const body: RowInput[] = lanes.slice(0, 3).map((row, i) => [
     {
       content: stripMarkdown(row.route) || `Lane ${i + 1}`,
@@ -577,10 +745,9 @@ function drawTradeLanesTable(doc: jsPDF, ov: ExecutiveOverview, startY: number):
       content: Number.isFinite(row.transit_days) ? `${row.transit_days} days` : "—",
       styles: { halign: "right" },
     },
-    {
-      content: stripMarkdown(row.velocity_status) || "Moderate",
-      styles: { halign: "center" },
-    },
+    // Empty content — autoTable draws nothing, didDrawCell paints the
+    // pill in a cleanly empty cell.
+    { content: "", styles: { halign: "center" } },
   ]);
 
   autoTable(doc, {
@@ -612,24 +779,30 @@ function drawTradeLanesTable(doc: jsPDF, ov: ExecutiveOverview, startY: number):
       fillColor: INK_50,
     },
     didDrawCell: (data) => {
-      // Status column — render the value as a pill instead of plain text.
+      // Velocity status column — autoTable drew an empty cell because
+      // body[r][3].content === "". Paint the pill directly into the
+      // empty cell, looked up from the parallel velocityStatuses array
+      // by row index. No more white-rect overpaint hack.
       if (data.section === "body" && data.column.index === 3) {
-        const status = String(data.cell.raw && (data.cell.raw as any).content || "Moderate");
+        const status = velocityStatuses[data.row.index] || "Moderate";
         const colors = pillColorsForStatus(status);
-        // Clear the underlying text by painting a white rect.
-        doc.setFillColor(...WHITE);
-        doc.rect(data.cell.x + 1, data.cell.y + 1, data.cell.width - 2, data.cell.height - 2, "F");
-        const cx = data.cell.x + data.cell.width / 2;
-        const cy = data.cell.y + data.cell.height / 2 - 6;
         doc.setFont("helvetica", "bold");
         doc.setFontSize(8);
         const tw = doc.getTextWidth(status);
-        const pw = tw + 16;
+        const pw = Math.min(tw + 16, data.cell.width - 4);
         const ph = 14;
+        const cx = data.cell.x + data.cell.width / 2;
+        const cy = data.cell.y + (data.cell.height - ph) / 2;
         doc.setFillColor(...colors.bg);
         doc.roundedRect(cx - pw / 2, cy, pw, ph, ph / 2, ph / 2, "F");
         doc.setTextColor(...colors.fg);
-        doc.text(status, cx - tw / 2, cy + ph - 4);
+        // Truncate text to fit if the pill width was clamped by cell.
+        let label = status;
+        while (doc.getTextWidth(label) > pw - 12 && label.length > 4) {
+          label = `${label.slice(0, -2)}…`;
+        }
+        const lw = doc.getTextWidth(label);
+        doc.text(label, cx - lw / 2, cy + ph - 4);
       }
     },
   });
@@ -752,7 +925,11 @@ export function exportPulseExecutivePdf(args: ExportArgs): void {
   doc.setFillColor(...WHITE);
   doc.rect(0, 0, PAGE_W, PAGE_H, "F");
 
-  const ov: ExecutiveOverview = args.brief?.report?.executive_overview ?? {};
+  // Route every render through the backwards-compat layer so cached
+  // briefs from before the 2026-06-18 schema redesign still produce
+  // a populated PDF rather than an all-pending-pill skeleton. Briefs
+  // generated against the new schema short-circuit and return as-is.
+  const ov: ExecutiveOverview = buildExecutiveOverviewWithFallback(args, args.brief?.report ?? undefined);
   const freshnessLabel = stripMarkdown(ov.data_freshness_label) || "REAL-TIME CUSTOMS MANIFEST";
 
   // Block 1: title + opportunity index + corporate metadata sub-header.

--- a/supabase/functions/pulse-ai-enrich/index.ts
+++ b/supabase/functions/pulse-ai-enrich/index.ts
@@ -1,3 +1,13 @@
+// Force redeploy 2026-06-18T23:35Z — Studio White schema (PRs #115/116)
+// merged at d8e5202c but the supabase-auto-deploy workflow didn't pick
+// up the change in production (live fn updated_at was still
+// 2026-06-17 16:32 UTC, hours before the merge). Touching the file
+// from this branch re-triggers the path filter on the deploy
+// workflow so the new executive_overview schema actually lands in
+// production. Without this, every brief regeneration still produces
+// the legacy tldr / pre_call_talking_points / objections shape, which
+// the new PDF generator cannot read — rendering every section as an
+// [Enrichment in Progress] pill.
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
 import { createLogger } from "../_shared/logger.ts";


### PR DESCRIPTION
…ll bug

User CEO feedback: "the pulse ai generated the exact same brief as before and the pdf looks even worst." Investigation surfaced THREE root causes, fixed here in lockstep:

1. Edge function never deployed since 2026-06-17 16:32 UTC -------------------------------------------------------- PRs #115 and #116 merged the Studio White redesign at d8e5202c (2026-06-18 22:23 UTC), which rewrote the executive_overview JSON schema in pulse-ai-enrich. The supabase-auto-deploy workflow's path filter should have matched, but the live function's updated_at on Supabase stayed at 2026-06-17 — meaning the workflow either didn't fire or silently failed.

   Verified via Supabase MCP get_edge_function (version 47, updated_at 1781713956258) AND via lit_pulse_ai_reports query: 0 of 14 non-expired rows have the new shape; 4 have the old shape; 10 have no executive_overview block at all. Most recent regen at 22:21:37 UTC (three minutes before user complaint) STILL came back with old shape — the LLM is still being instructed with the pre-redesign prompt.

   Fix: add a force-redeploy comment at the top of pulse-ai-enrich/index.ts so the path filter re-triggers the workflow on this merge. The diff is comment-only; the schema rewrite from #115/#116 stays unchanged.

2. PDF backwards-compatibility fallback layer ------------------------------------------ Even with the edge fn redeployed, every existing cached brief in lit_pulse_ai_reports.report_json has the OLD shape (tldr / pre_call_talking_points / likely_objections / best_contact_and_approach). The new PDF generator only reads new field names (corporate_metadata / executive_macro_briefing / logistics_volumetrics / trade_lane_velocity / friction_points / supply_chain_leadership), so for every cached brief, EVERY section renders as an [Enrichment in Progress] pill — looks broken end- to-end. That is what the user reported.

   Adds buildExecutiveOverviewWithFallback() that detects new-shape briefs (short-circuit) vs old-shape briefs (synthesise new blocks from legacy fields):

   - corporate_metadata    ← args.companyName / industry / hq
   - executive_macro_briefing ← company_summary + " " + why_now
   - logistics_volumetrics ← key_metrics_snapshot.teu_12m +
                              carrier_opportunities + lane count
   - trade_lane_velocity   ← lane_insights[0..3] (Moderate status)
   - friction_points       ← risk_flags ZIP carrier_opportunities
                              + forwarder_displacement_opportunities
   - supply_chain_leadership ← recommended_contacts filtered by
                                isLogisticsLeadershipTitle, top 2

   No field is fabricated — any missing source still produces a pending pill, just at section level instead of for every individual data point. Effect for the user: Old Navy renders a populated PDF now from the existing cached brief, immediately, without waiting for the edge fn to redeploy.

3. Trade lane velocity pill rendering bug --------------------------------------- drawTradeLanesTable's didDrawCell painted a WHITE rect over the cell to clear the text autoTable had already drawn, then painted the pill on top. Two problems: (a) on alternating rows (INK_50 background), the white rect leaves a visible white box inside a gray row; (b) the rect inset of 1pt leaves a hairline of original text bleeding through at the cell edge.

   Fixed by holding the velocity strings in a parallel side array (`velocityStatuses[]`) and passing `content: ""` for column 3 in the body. autoTable draws nothing in the cell; didDrawCell paints the pill into a cleanly empty cell. Also clamps pill width to cell width (with `…` truncation) so long labels like "Transit Congestion Warning" can't overflow into adjacent columns.

4. Volumetrics grid pending text rendering ---------------------------------------- The 3-card metric grid was rendering [Enrichment in Progress] as raw 10pt text in the same slot where the regular value renders as 18pt bold. Made the cards look broken when fields were missing. Replaced with drawPendingPill() (same yellow pill component used elsewhere) so empty cards feel intentional rather than half-rendered.

Verification path after merge:
- Vercel auto-deploys frontend (PDF backwards-compat goes live).
- Supabase auto-deploy fires on the comment-touched edge fn (new schema goes live, future regens produce new shape).
- User can immediately Export PDF on Old Navy and see a populated Studio White brief from cached data; clicking "Refresh brief" after the edge fn deploys upgrades it to full new-shape content.