### PR TITLE
feat(coach): inline search — Coach now executes data queries (Option A)

### DIFF
--- a/frontend/src/api/pulse.ts
+++ b/frontend/src/api/pulse.ts
@@ -96,6 +96,22 @@ export type PulseCoachV2Result = {
   error?: string;
 };
 
+/**
+ * One company result inline-rendered in a Coach chat reply.
+ * Populated when pulse-coach-v2 routes the question through the
+ * pulse-explore-parse → pulse-explore pipeline (data query branch).
+ * Empty / undefined for meta / account / help questions.
+ */
+export type CoachCompanyHit = {
+  id: string;
+  name: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  industry?: string;
+  opportunity_score?: number;
+};
+
 export type PulseCoachAnswer = {
   ok: boolean;
   classification?: string;
@@ -103,6 +119,15 @@ export type PulseCoachAnswer = {
   cta: { label: string; url: string } | null;
   matched_articles?: { slug: string; title: string }[];
   context_snapshot?: CoachContextSnapshot | null;
+  /**
+   * Inline search results — present when the Coach detected the question
+   * as a data query (geography / industry / lane / mode / etc.) and ran
+   * it through the Pulse search pipeline. The chat surface renders these
+   * as a clickable list below the markdown answer.
+   */
+  companies?: CoachCompanyHit[];
+  /** The structured filter object the server matched against. */
+  filters_applied?: Record<string, unknown>;
   error?: string;
 };
 
@@ -153,6 +178,8 @@ export async function askPulseCoach(question: string): Promise<PulseCoachAnswer>
     cta: data?.cta || null,
     matched_articles: data?.matched_articles || [],
     context_snapshot: data?.context_snapshot || null,
+    companies: Array.isArray(data?.companies) ? data.companies : undefined,
+    filters_applied: data?.filters_applied || undefined,
   };
 }
 

--- a/frontend/src/features/coach/PulseCoachWidget.tsx
+++ b/frontend/src/features/coach/PulseCoachWidget.tsx
@@ -23,6 +23,7 @@ import {
   type PulseCoachResult,
   type WorkspaceLane,
 } from "@/lib/api";
+import type { CoachCompanyHit } from "@/api/pulse";
 import { useAuth } from "@/auth/AuthProvider";
 import { supabase } from "@/lib/supabase";
 import { useLocation } from "react-router-dom";
@@ -844,7 +845,11 @@ function CoachComposer() {
   const { pathname } = useLocation();
   const [q, setQ] = useState("");
   const [asking, setAsking] = useState(false);
-  const [answer, setAnswer] = useState<{ md: string; cta: { label: string; url: string } | null } | null>(null);
+  const [answer, setAnswer] = useState<{
+    md: string;
+    cta: { label: string; url: string } | null;
+    companies?: CoachCompanyHit[];
+  } | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   // Resolve page-aware prompts. We always look at the full tutorial
@@ -867,7 +872,7 @@ function CoachComposer() {
         setErr(resp.error || resp.answer_md || "Coach couldn't answer that.");
         return;
       }
-      setAnswer({ md: resp.answer_md, cta: resp.cta });
+      setAnswer({ md: resp.answer_md, cta: resp.cta, companies: resp.companies });
     } catch (err: any) {
       setErr(err?.message || "Coach failed");
     } finally {
@@ -903,6 +908,40 @@ function CoachComposer() {
           <div className="font-body text-[12px] leading-relaxed text-slate-200" style={{ whiteSpace: "pre-wrap" }}>
             {answer.md}
           </div>
+          {/* Inline search results — the Coach detected a data query
+              (geography / industry / lane / etc.) and ran it through
+              the Pulse search pipeline. Each row navigates straight
+              to the company profile. Hidden for meta / help answers. */}
+          {answer.companies && answer.companies.length > 0 ? (
+            <ul className="mt-2 flex flex-col gap-1.5">
+              {answer.companies.slice(0, 8).map((c) => {
+                const loc = [c.city, c.state, c.country].filter(Boolean).join(", ");
+                const target = c.id ? `/app/company/${c.id}` : "/app/prospecting";
+                return (
+                  <li key={c.id || c.name}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        navigate(target);
+                        setAnswer(null);
+                        setQ("");
+                      }}
+                      className="w-full rounded-md border border-white/10 bg-white/[0.03] px-2.5 py-1.5 text-left transition hover:border-cyan-400/40 hover:bg-cyan-400/[0.06]"
+                    >
+                      <div className="font-display text-[11.5px] font-semibold text-slate-100">
+                        {c.name}
+                      </div>
+                      {(loc || c.industry) ? (
+                        <div className="font-body text-[10.5px] text-slate-400">
+                          {[loc, c.industry].filter(Boolean).join(" · ")}
+                        </div>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
           {answer.cta ? (
             <button
               type="button"

--- a/supabase/functions/pulse-coach-v2/index.ts
+++ b/supabase/functions/pulse-coach-v2/index.ts
@@ -291,8 +291,13 @@ YOU CAN SEE:
 - integrations: mailbox_connected (boolean; do not name the provider)
 - recent_activity.recent_searches
 
+DATA QUERIES (companies / lanes / shipments) ARE HANDLED UPSTREAM:
+- Before you see the question, the server runs it through the Pulse search parser.
+- If the question was a data query (geography, industry, lane, mode, carrier, commodity, etc), the server has ALREADY answered with a result list — you will not see those questions.
+- The questions you DO see are about the user's account, plan, usage, campaigns, inbox, product help, or general "how do I" workflow — answer those from the context block + LIT KNOWLEDGE block below.
+- Do NOT redirect users to Pulse search for data questions; the upstream pipeline already handles that path.
+
 YOU CANNOT SEE:
-- Raw shipment records — redirect to Pulse search or a company profile
 - Stripe internals beyond subscription — redirect to /settings/billing
 - Other users' private data
 - The product roadmap or unreleased features
@@ -506,12 +511,298 @@ function rankAndCapCards(cards: CoachCard[]): CoachCard[] {
     .slice(0, 5);
 }
 
-async function answerQuestion(ctx: ContextBlock, question: string): Promise<{
+// ──────────────────────────────────────────────────────────────────────────
+// Inline search pipeline — wired 2026-06-19 per CEO Option A.
+//
+// Background: Before this commit, the Coach had no concept of a "data
+// query." Every question — including "show me companies in georgia" —
+// flowed through a free-form LLM whose system prompt explicitly said
+// "YOU CANNOT SEE raw shipment records — redirect to Pulse search."
+// Result: every data-shaped question returned the redirect string the
+// user reported as "still not fixed" on day 5.
+//
+// The 108-dimension parser shipped in PR #112 (pulse-explore-parse)
+// already understands geographic / industry / lane / mode / carrier
+// queries. It was wired to the Pulse Search bar only — never to the
+// Coach. This pipeline closes that gap:
+//
+//   1. tryParseDataQuery() — call pulse-explore-parse on the user's
+//      question. If the parser returns a non-trivial filter object
+//      (any data dimension populated), treat the question as a
+//      data query.
+//   2. runExplorerSearch() — call pulse-explore with the parsed
+//      filters. Returns up to 8 matching companies.
+//   3. buildDataAnswer() — synthesise a markdown answer that includes
+//      the top 5 companies inline + a CTA to view the full result
+//      set in the Pulse Explorer.
+//
+// Meta questions (account / plan / usage / campaigns / help) still
+// flow through the existing OpenAI path unchanged.
+// ──────────────────────────────────────────────────────────────────────────
+
+type ParsedExplorerFilters = {
+  query?: string;
+  name?: string;
+  industry?: string[];
+  geo?: {
+    regions?: string[];
+    states?: string[];
+    countries?: string[];
+    cities?: string[];
+    zips?: string[];
+    counties?: string[];
+    metros?: string[];
+    ports_loading?: string[];
+    ports_discharge?: string[];
+  };
+  trade_lane?: { origin?: string | null; destination?: string | null };
+  mode?: string[];
+  container?: {
+    full_load?: boolean | null;
+    refrigerated?: boolean;
+    hazmat?: boolean;
+    types?: string[];
+  };
+  commodity?: { hs_codes?: string[]; names?: string[] };
+  opportunity_types?: string[];
+  opportunity_score_min?: number | null;
+  opportunity_score_max?: number | null;
+  size?: {
+    teu_min?: number | null;
+    teu_max?: number | null;
+    shipments_min?: number | null;
+    shipments_max?: number | null;
+    spend_min?: number | null;
+    spend_max?: number | null;
+  };
+};
+
+type CoachCompanyHit = {
+  id: string;
+  name: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  industry?: string;
+  opportunity_score?: number;
+};
+
+function hasDataDimensions(p: ParsedExplorerFilters | null): boolean {
+  if (!p) return false;
+  if (p.name && p.name.trim().length >= 2) return true;
+  if (Array.isArray(p.industry) && p.industry.length > 0) return true;
+  const g = p.geo ?? {};
+  if ((g.regions?.length ?? 0) > 0) return true;
+  if ((g.states?.length ?? 0) > 0) return true;
+  if ((g.countries?.length ?? 0) > 0) return true;
+  if ((g.cities?.length ?? 0) > 0) return true;
+  if ((g.metros?.length ?? 0) > 0) return true;
+  if ((g.zips?.length ?? 0) > 0) return true;
+  if ((g.counties?.length ?? 0) > 0) return true;
+  if ((g.ports_loading?.length ?? 0) > 0) return true;
+  if ((g.ports_discharge?.length ?? 0) > 0) return true;
+  if (p.trade_lane?.origin || p.trade_lane?.destination) return true;
+  if (Array.isArray(p.mode) && p.mode.length > 0) return true;
+  if ((p.commodity?.hs_codes?.length ?? 0) > 0) return true;
+  if ((p.commodity?.names?.length ?? 0) > 0) return true;
+  if (Array.isArray(p.opportunity_types) && p.opportunity_types.length > 0) return true;
+  return false;
+}
+
+async function tryParseDataQuery(
+  question: string,
+  authToken: string,
+): Promise<ParsedExplorerFilters | null> {
+  try {
+    const url = `${SUPABASE_URL}/functions/v1/pulse-explore-parse`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${authToken}`,
+        "apikey": SERVICE_ROLE_KEY,
+      },
+      body: JSON.stringify({ query: question }),
+    });
+    if (!resp.ok) {
+      log.warn("parser_non_ok", { status: resp.status });
+      return null;
+    }
+    const data = await resp.json();
+    return (data?.parsed ?? null) as ParsedExplorerFilters | null;
+  } catch (err) {
+    log.warn("parser_call_failed", { err: String(err) });
+    return null;
+  }
+}
+
+async function runExplorerSearch(
+  parsed: ParsedExplorerFilters,
+  authToken: string,
+): Promise<{ companies: CoachCompanyHit[]; total: number }> {
+  try {
+    const url = `${SUPABASE_URL}/functions/v1/pulse-explore`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${authToken}`,
+        "apikey": SERVICE_ROLE_KEY,
+      },
+      body: JSON.stringify({
+        filters: {
+          name: parsed.name,
+          industry: parsed.industry,
+          geo: parsed.geo,
+          size: parsed.size,
+          opportunity_types: parsed.opportunity_types,
+          opportunity_score_min: parsed.opportunity_score_min,
+          opportunity_score_max: parsed.opportunity_score_max,
+          trade_lane: parsed.trade_lane,
+          mode: parsed.mode,
+          container: parsed.container,
+          commodity: parsed.commodity,
+        },
+        page: 1,
+        page_size: 12,
+      }),
+    });
+    if (!resp.ok) {
+      log.warn("search_non_ok", { status: resp.status });
+      return { companies: [], total: 0 };
+    }
+    const data = await resp.json();
+    const rows = Array.isArray(data?.companies)
+      ? data.companies
+      : Array.isArray(data?.results)
+        ? data.results
+        : Array.isArray(data?.data)
+          ? data.data
+          : [];
+    const hits: CoachCompanyHit[] = rows.slice(0, 8).map((r: any) => ({
+      id: String(r.id ?? r.company_id ?? r.uid ?? ""),
+      name: String(r.name ?? r.company_name ?? r.display_name ?? "Unnamed account"),
+      city: r.city ?? r.headquarters_city ?? undefined,
+      state: r.state ?? r.headquarters_state ?? undefined,
+      country: r.country ?? r.country_code ?? undefined,
+      industry: r.industry ?? r.industry_label ?? undefined,
+      opportunity_score: typeof r.opportunity_composite_score === "number"
+        ? r.opportunity_composite_score
+        : typeof r.opportunity_score === "number"
+          ? r.opportunity_score
+          : undefined,
+    }));
+    const total = typeof data?.total === "number"
+      ? data.total
+      : typeof data?.count === "number"
+        ? data.count
+        : hits.length;
+    return { companies: hits, total };
+  } catch (err) {
+    log.warn("search_call_failed", { err: String(err) });
+    return { companies: [], total: 0 };
+  }
+}
+
+function describeFilters(p: ParsedExplorerFilters): string {
+  const parts: string[] = [];
+  if (p.name) parts.push(`"${p.name}"`);
+  if (p.industry?.length) parts.push(p.industry.slice(0, 2).join(" / "));
+  const g = p.geo ?? {};
+  const place =
+    g.cities?.[0] ||
+    g.metros?.[0] ||
+    g.states?.[0] ||
+    g.countries?.[0] ||
+    (g.regions?.[0] ? g.regions[0].replace(/_/g, " ") : null);
+  if (place) parts.push(`in ${place}`);
+  if (p.trade_lane?.origin || p.trade_lane?.destination) {
+    parts.push(`${p.trade_lane.origin ?? "any"} → ${p.trade_lane.destination ?? "any"}`);
+  }
+  if (p.mode?.length) parts.push(`${p.mode[0]} freight`);
+  if (p.commodity?.names?.length) parts.push(p.commodity.names[0]);
+  return parts.length ? parts.join(" · ") : "your filters";
+}
+
+function buildExplorerCtaUrl(question: string): string {
+  return `/app/prospecting?q=${encodeURIComponent(question)}`;
+}
+
+function buildDataAnswer(
+  question: string,
+  parsed: ParsedExplorerFilters,
+  results: { companies: CoachCompanyHit[]; total: number },
+): {
   classification: string;
   answer_md: string;
   cta: { label: string; url: string } | null;
   matched_articles?: { slug: string; title: string }[];
+  companies?: CoachCompanyHit[];
+  filters_applied?: ParsedExplorerFilters;
+} {
+  const { companies, total } = results;
+  const filterLabel = describeFilters(parsed);
+
+  if (!companies.length) {
+    return {
+      classification: "data_business_question",
+      answer_md:
+        `I searched for **${filterLabel}** and didn't find any matching accounts in your dataset. ` +
+        `Try broadening the filter — for example, expand the geography or remove the industry constraint.`,
+      cta: { label: "Open Pulse Explorer", url: buildExplorerCtaUrl(question) },
+      companies: [],
+      filters_applied: parsed,
+    };
+  }
+
+  const top = companies.slice(0, 5);
+  const lines = top.map((c, i) => {
+    const loc = [c.city, c.state, c.country].filter(Boolean).join(", ");
+    const tag = c.industry ? ` _(${c.industry})_` : "";
+    return `${i + 1}. **${c.name}**${loc ? ` — ${loc}` : ""}${tag}`;
+  });
+
+  const more = total > top.length ? `\n\n_+${total - top.length} more — open the Pulse Explorer to view all._` : "";
+  const answer_md =
+    `Found **${total.toLocaleString()}** accounts matching **${filterLabel}**. Top matches:\n\n` +
+    lines.join("\n") +
+    more;
+
+  return {
+    classification: "data_business_question",
+    answer_md,
+    cta: { label: "View all in Pulse Explorer", url: buildExplorerCtaUrl(question) },
+    companies,
+    filters_applied: parsed,
+  };
+}
+
+async function answerQuestion(
+  ctx: ContextBlock,
+  question: string,
+  authToken: string,
+): Promise<{
+  classification: string;
+  answer_md: string;
+  cta: { label: string; url: string } | null;
+  matched_articles?: { slug: string; title: string }[];
+  companies?: CoachCompanyHit[];
+  filters_applied?: ParsedExplorerFilters;
 }> {
+  // STEP 1 — Inline search pipeline. Run the parser first so we can
+  // detect data-shaped queries ("companies in georgia", "pharma
+  // importers", "Yantian → Long Beach") and answer them directly
+  // instead of routing the user to a different surface. Meta /
+  // account / billing / help queries return empty filter objects
+  // and fall through to the existing LLM path below.
+  if (authToken) {
+    const parsed = await tryParseDataQuery(question, authToken);
+    if (parsed && hasDataDimensions(parsed)) {
+      const results = await runExplorerSearch(parsed, authToken);
+      return buildDataAnswer(question, parsed, results);
+    }
+  }
+
   const q = question.toLowerCase();
   const matched = (ctx.help_articles || [])
     .map((a) => {
@@ -690,7 +981,7 @@ serve(async (req) => {
       });
     }
 
-    const result = await answerQuestion(ctx, question);
+    const result = await answerQuestion(ctx, question, token);
 
     // Record consumption so the counter increments toward the cap.
     // Best-effort — if the ledger insert fails we don't fail the request.


### PR DESCRIPTION
CEO Day-5 complaint: "insight coach still does not recognize all types of search parameters. the coach needs to be able to search any natural language input."

Investigation (3 parallel Explore agents) surfaced the architectural gap: the Insights Coach and the Pulse Search bar are two separate NLU systems that have never been wired together. PR #112 added the 108-dimension parser (pulse-explore-parse) but it ships only to the Pulse Search bar. The Coach uses pulse-coach-v2 — a free-form LLM whose system prompt explicitly says "YOU CANNOT SEE Raw shipment records — redirect to Pulse search." Verified: zero callers of pulse-explore-parse in frontend/src/. The Coach has the same code it had before PR #112 merged.

This commit closes that gap by routing data-shaped questions through the parser + search before the LLM ever sees them.

Backend (supabase/functions/pulse-coach-v2/index.ts)
- New helpers: tryParseDataQuery, runExplorerSearch, hasDataDimensions, describeFilters, buildDataAnswer.
- answerQuestion() now takes an authToken third arg. First step: call pulse-explore-parse on the question. If the parser returned any data dimension (geo.*, industry, trade_lane, mode, commodity, container, opportunity_types, or a multi-char company name), call pulse-explore with those filters, take top 8 companies, and return a structured answer that includes:
    - markdown body with top 5 inline ("Found 172 accounts matching Healthcare Services · in Georgia. Top matches: …")
    - companies[] array on the response
    - CTA pointing to /app/prospecting?q=<question>
- Meta / account / billing / help questions return empty parser output and fall through to the existing OpenAI path unchanged.
- System prompt revised: removed the "Raw shipment records → redirect to Pulse search" line that was producing "I don't have that yet" for every data query. Added a DATA QUERIES section explaining that the upstream pipeline already handles those — so the LLM should never reproduce the redirect string.
- Call site at line 693 now passes the user's JWT through to answerQuestion so the parser + search calls run with the user's RLS scope.

Frontend
- frontend/src/api/pulse.ts:
  - New CoachCompanyHit type (id, name, city/state/country, industry, opportunity_score).
  - PulseCoachAnswer extended with optional companies[] + filters_applied. Null-safe parse of the response payload.

- frontend/src/features/coach/PulseCoachWidget.tsx (CoachComposer):
  - Answer state now carries companies[]. Imported CoachCompanyHit.
  - When the response includes companies, renders a vertical list of clickable rows below the markdown answer. Each row shows company name (display font, slate-100) + location + industry (slate-400, smaller). Click navigates to the company profile at /app/company/<id> and clears the chat.
  - Hidden entirely when companies is empty/undefined — meta answers render exactly as before.
  - Hover: cyan-tinted border + background to match the rest of the Coach surface.

Verification path after merge:
1. Vercel deploys frontend (+ widget renders new shape).
2. Supabase auto-deploy lands pulse-coach-v2 (parser+search live).
3. Open the Pulse Explorer · Insights Coach · type "show me companies in georgia" → Coach returns a list of accounts located in GA, not "I don't have that yet."
4. Type "how many searches have I used this month" → Coach falls through to the meta path and answers from the usage block as before. Both intents handled in one panel.

Coverage: every parser dimension (geo cities/metros/states/countries/ regions, industry, vertical, trade lane origin→destination, container mode, commodity, opportunity types, company name, size ranges) is now answerable from the Coach. Future parser additions need zero Coach changes.