### PR TITLE
feat: Quoting Phase 1 follow-ups — saved-company search, Save/Send fixes, auto-mileage, autocomplete, Quote Settings

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ const EmailCenter = lazy(() => import("@/pages/EmailCenter"));
 // Route below redirects /app/rfp → /app/dashboard so old bookmarks land softly.
 const QuotingDashboard = lazy(() => import("@/features/quoting/QuotingDashboard"));
 const QuoteBuilder = lazy(() => import("@/features/quoting/QuoteBuilder"));
+const QuoteSettings = lazy(() => import("@/features/quoting/QuoteSettings"));
 const Settings = lazy(() => import("@/pages/SettingsPage"));
 const Billing = lazy(() => import("@/pages/BillingNew"));
 const AffiliateDash = lazy(() => import("@/pages/AffiliateDashboard"));
@@ -497,6 +498,16 @@ export default function App() {
             <RequireAuth>
               <LITPage>
                 <QuoteBuilder />
+              </LITPage>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/app/quoting/settings"
+          element={
+            <RequireAuth>
+              <LITPage>
+                <QuoteSettings />
               </LITPage>
             </RequireAuth>
           }

--- a/frontend/src/api/quoting.ts
+++ b/frontend/src/api/quoting.ts
@@ -119,6 +119,15 @@ export interface QuoteListItem {
   } | null;
 }
 
+export interface CompanySearchHit {
+  source_company_key: string;
+  company_name: string;
+  country?: string | null;
+  city?: string | null;
+  total_shipments?: number | null;
+  total_teu?: number | null;
+}
+
 export interface DashboardMetrics {
   draft: number;
   sent: number;
@@ -307,6 +316,8 @@ export const quoting = {
     res.data = coerceNums(res.data, NUMERIC_METRIC_FIELDS) as DashboardMetrics;
     return res;
   },
+  companySearch: (q: string) =>
+    invoke<{ ok: true; items: CompanySearchHit[] }>("quote-company-search", { q, limit: 8 }),
   companyMetrics: async (company_id: string) => {
     const res = await invoke<{ ok: true; data: CompanyMetrics }>("quote-company-metrics", {
       company_id,

--- a/frontend/src/api/quoting.ts
+++ b/frontend/src/api/quoting.ts
@@ -318,6 +318,17 @@ export const quoting = {
   },
   companySearch: (q: string) =>
     invoke<{ ok: true; items: CompanySearchHit[] }>("quote-company-search", { q, limit: 8 }),
+  /**
+   * Auto-mileage for a domestic lane. Geocodes origin + destination via
+   * Nominatim and returns OSRM driving miles (rounded). `miles` is null when
+   * inputs are too short or a location can't be geocoded — callers must NOT
+   * fabricate a number in that case.
+   */
+  distance: (origin: string, destination: string) =>
+    invoke<{ ok: true; miles: number | null; source?: string; reason?: string }>(
+      "quote-distance",
+      { origin, destination },
+    ),
   companyMetrics: async (company_id: string) => {
     const res = await invoke<{ ok: true; data: CompanyMetrics }>("quote-company-metrics", {
       company_id,

--- a/frontend/src/api/quoting.ts
+++ b/frontend/src/api/quoting.ts
@@ -120,12 +120,12 @@ export interface QuoteListItem {
 }
 
 export interface CompanySearchHit {
-  source_company_key: string;
+  company_id: string;
   company_name: string;
-  country?: string | null;
+  domain?: string | null;
   city?: string | null;
-  total_shipments?: number | null;
-  total_teu?: number | null;
+  country?: string | null;
+  shipments_12m?: number | null;
 }
 
 export interface DashboardMetrics {

--- a/frontend/src/api/quoting.ts
+++ b/frontend/src/api/quoting.ts
@@ -187,6 +187,26 @@ export interface QuoteUpdateInput extends QuoteCreateInput {
 }
 
 /**
+ * Org-level quote branding + defaults, persisted via `quote-settings-*` edge
+ * functions. `logo_url` / `signature_url` may be base64 data-URIs (resized
+ * client-side before save to stay under the server's 700k-char cap).
+ */
+export interface QuoteSettings {
+  company_name?: string;
+  company_address?: string;
+  company_email?: string;
+  company_phone?: string;
+  logo_url?: string;
+  signature_url?: string;
+  signature_name?: string;
+  prepared_by?: string;
+  default_payment_terms?: string;
+  default_fuel_surcharge_pct?: number;
+  default_currency?: string;
+  terms_text?: string;
+}
+
+/**
  * Invoke a `quote-*` edge function. Delegates to the shared `invokeEdge`
  * helper, which throws `EdgeFunctionError` on transport failures and on
  * application-level `{ ok: false }` responses.
@@ -336,4 +356,23 @@ export const quoting = {
     res.data = coerceNums(res.data, NUMERIC_METRIC_FIELDS) as CompanyMetrics;
     return res;
   },
+  /**
+   * Fetch the org's quote branding/defaults plus org-derived starting values
+   * (org_name / org_logo_url) so first-time users see their workspace name +
+   * logo pre-filled. Auth-only (any member can read).
+   */
+  settingsGet: () =>
+    invoke<{
+      ok: true;
+      data: { org_name: string | null; org_logo_url: string | null; settings: QuoteSettings };
+    }>("quote-settings-get", {}),
+  /**
+   * Persist quote branding/defaults. Admin-only on the server: non-admins get
+   * `{ ok:false, code:"FORBIDDEN" }` (403); an oversized data-URI logo/signature
+   * returns `code:"IMAGE_TOO_LARGE"` (413). Both surface as `EdgeFunctionError`.
+   */
+  settingsUpdate: (settings: QuoteSettings) =>
+    invoke<{ ok: true; data: { settings: QuoteSettings } }>("quote-settings-update", {
+      settings,
+    }),
 };

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -20,12 +20,13 @@ import {
   Send,
 } from "lucide-react";
 import { useAuth } from "@/auth/AuthProvider";
+import { useEntitlements } from "@/hooks/useEntitlements";
 import { canAccessFeature } from "@/lib/planLimits";
 import { logout } from "@/auth/supabaseAuthClient";
 import { LockoutBanner } from "@/components/subscription/LockoutBanner";
 import NotificationBell from "@/components/layout/NotificationBell";
 
-function SideLink({ to, icon: Icon, label, locked = false, onClick = null }) {
+function SideLink({ to, icon: Icon, label, locked = false, lockHint = false, onClick = null }) {
   const baseClass =
     "flex items-center justify-between px-4 py-3 mx-2 rounded-xl transition-all duration-200";
 
@@ -48,6 +49,7 @@ function SideLink({ to, icon: Icon, label, locked = false, onClick = null }) {
   return (
     <NavLink
       to={to}
+      title={lockHint ? "Upgrade to Growth to create and send quotes" : undefined}
       className={({ isActive }) =>
         `${baseClass} ${
           isActive
@@ -60,6 +62,7 @@ function SideLink({ to, icon: Icon, label, locked = false, onClick = null }) {
         <Icon size={18} className="mr-3 shrink-0" />
         {label}
       </span>
+      {lockHint && <Lock size={14} className="opacity-70 shrink-0" />}
     </NavLink>
   );
 }
@@ -133,10 +136,16 @@ export default function AppShell({ currentPageName, children }) {
   const [collapsed, setCollapsed] = useState(false);
   const location = useLocation();
 
+  const { entitlements } = useEntitlements();
+
   const isAdmin = Boolean(canAccessAdmin || isOrgAdmin || isSuperAdmin);
   const showCampaigns = isAdmin || canAccessFeature(plan, "campaign_builder");
   const showPulse = isAdmin || canAccessFeature(plan, "pulse");
   const showAdminSection = isAdmin;
+  // Lock Quoting ONLY when the server explicitly reports the feature as false.
+  // While the entitlements payload predates the quoting key (undefined) or is
+  // still loading, leave it unlocked — the server enforces on every mutation.
+  const quotingLocked = !isAdmin && entitlements?.features?.quoting === false;
 
   const breadcrumbs = useMemo(() => {
     const path = location.pathname.replace(/^\/+|\/+$|\?.*$/g, "");
@@ -219,11 +228,11 @@ export default function AppShell({ currentPageName, children }) {
                 />
               )
             )}
-            {/* TODO: gate on quoting entitlement — server enforces anyway. */}
             <SideLink
               to="/app/quoting"
               icon={FileText}
               label={collapsed ? "" : "Quoting"}
+              lockHint={!collapsed && quotingLocked}
             />
             {showPulse && (
               <SideLink
@@ -397,8 +406,7 @@ export default function AppShell({ currentPageName, children }) {
               ) : (
                 <SideLink to="#" icon={Mail} label="Campaigns" locked onClick={lockedClick} />
               )}
-              {/* TODO: gate on quoting entitlement — server enforces anyway. */}
-              <SideLink to="/app/quoting" icon={FileText} label="Quoting" />
+              <SideLink to="/app/quoting" icon={FileText} label="Quoting" lockHint={quotingLocked} />
               {showPulse && (
                 <SideLink to="/app/prospecting" icon={TrendingUp} label="Pulse" />
               )}

--- a/frontend/src/features/company/CompanyQuotesTab.tsx
+++ b/frontend/src/features/company/CompanyQuotesTab.tsx
@@ -34,9 +34,11 @@ import {
   FileDown,
   Plus,
   FileText,
+  Sparkles,
 } from "lucide-react";
 
 import { quoting } from "@/api/quoting";
+import { useEntitlements } from "@/hooks/useEntitlements";
 import type { QuoteListItem, QuoteMode, QuoteCreateInput } from "@/api/quoting";
 import EnhancedKpiCard from "@/components/dashboard/EnhancedKpiCard";
 import LitSectionCard from "@/components/ui/LitSectionCard";
@@ -75,6 +77,13 @@ function formatMargin(pct?: number | null): string {
 export default function CompanyQuotesTab({ companyId }: { companyId: string }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { entitlements, isAdmin } = useEntitlements();
+  // KPIs + list stay visible on every plan; only "New Quote" is gated when the
+  // server explicitly disables quoting.
+  const quotingLocked = !isAdmin && entitlements?.features?.quoting === false;
+  const newQuotePath = quotingLocked
+    ? "/app/billing"
+    : `/app/quoting/new?company_id=${companyId}`;
 
   const metricsKey = ["quoting", "companyMetrics", companyId];
   const listKey = ["quoting", "list", "company", companyId];
@@ -210,17 +219,21 @@ export default function CompanyQuotesTab({ companyId }: { companyId: string }) {
         </div>
         <button
           type="button"
-          onClick={() => navigate(`/app/quoting/new?company_id=${companyId}`)}
+          onClick={() => navigate(newQuotePath)}
+          title={quotingLocked ? "Upgrade to Growth to create quotes" : undefined}
           className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
           style={{
             fontFamily: "'Space Grotesk', sans-serif",
-            background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
-            boxShadow:
-              "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+            background: quotingLocked
+              ? "linear-gradient(180deg,#d97706,#b45309)"
+              : "linear-gradient(180deg,#2563eb,#1d4ed8)",
+            boxShadow: quotingLocked
+              ? "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)"
+              : "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
           }}
         >
-          <Plus className="w-4 h-4" />
-          New Quote
+          {quotingLocked ? <Sparkles className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+          {quotingLocked ? "Upgrade to create quotes" : "New Quote"}
         </button>
       </div>
 
@@ -253,7 +266,8 @@ export default function CompanyQuotesTab({ companyId }: { companyId: string }) {
           <QuotesSkeleton />
         ) : quotes.length === 0 ? (
           <EmptyState
-            onNew={() => navigate(`/app/quoting/new?company_id=${companyId}`)}
+            locked={quotingLocked}
+            onNew={() => navigate(newQuotePath)}
           />
         ) : (
           <div className="overflow-x-auto">
@@ -465,7 +479,7 @@ function QuotesSkeleton() {
   );
 }
 
-function EmptyState({ onNew }: { onNew: () => void }) {
+function EmptyState({ onNew, locked = false }: { onNew: () => void; locked?: boolean }) {
   return (
     <div className="flex flex-col items-center justify-center text-center px-6 py-14">
       <div className="w-12 h-12 rounded-xl bg-slate-100 grid place-items-center mb-4">
@@ -478,22 +492,27 @@ function EmptyState({ onNew }: { onNew: () => void }) {
         No quotes for this company yet
       </div>
       <p className="text-[13px] text-slate-500 mt-1 max-w-sm">
-        Create the first quote to start pricing, sending, and tracking revenue
-        for this company.
+        {locked
+          ? "Quoting is available on Growth and above. Upgrade to price, send, and track revenue for this company."
+          : "Create the first quote to start pricing, sending, and tracking revenue for this company."}
       </p>
       <button
         type="button"
         onClick={onNew}
+        title={locked ? "Upgrade to Growth to create quotes" : undefined}
         className="mt-5 inline-flex items-center justify-center gap-2 h-10 px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
         style={{
           fontFamily: "'Space Grotesk', sans-serif",
-          background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
-          boxShadow:
-            "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+          background: locked
+            ? "linear-gradient(180deg,#d97706,#b45309)"
+            : "linear-gradient(180deg,#2563eb,#1d4ed8)",
+          boxShadow: locked
+            ? "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)"
+            : "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
         }}
       >
-        <Plus className="w-4 h-4" />
-        New Quote
+        {locked ? <Sparkles className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+        {locked ? "Upgrade to create quotes" : "New Quote"}
       </button>
     </div>
   );

--- a/frontend/src/features/quoting/QuoteBuilder.tsx
+++ b/frontend/src/features/quoting/QuoteBuilder.tsx
@@ -57,8 +57,14 @@ import { exportQuotePdf } from "@/lib/quoting/exportQuotePdf";
  * Editable builder state. Keyed to QuoteCreateInput fields plus the line items
  * the table maintains. `company_id` is required by the server on create.
  */
+/** True for a canonical lit_companies UUID; false for an ImportYeti slug. */
+const isUuid = (v: unknown): v is string =>
+  typeof v === "string" &&
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v);
+
 interface BuilderState {
   company_id?: string;
+  source_company_key?: string;
   contact_id?: string;
   mode: QuoteMode;
   service_type?: string;
@@ -93,10 +99,13 @@ type Action =
   | { type: "setLineItems"; items: QuoteLineItem[] }
   | { type: "hydrate"; quote: Quote; line_items: QuoteLineItem[] };
 
-function initialState(companyId?: string): BuilderState {
+function initialState(companyKey?: string): BuilderState {
   // TODO: prefill from org_settings.quote_defaults once an endpoint exists.
+  // `?company_id=` from a saved-company launch is normally an internal UUID, but
+  // guard against a slug sneaking in by routing non-UUIDs to source_company_key.
   return {
-    company_id: companyId,
+    company_id: isUuid(companyKey) ? companyKey : undefined,
+    source_company_key: companyKey && !isUuid(companyKey) ? companyKey : undefined,
     mode: "ocean",
     currency: "USD",
     fuel_surcharge_pct: undefined,
@@ -114,6 +123,7 @@ function reducer(state: BuilderState, action: Action): BuilderState {
       const q = action.quote;
       return {
         company_id: q.company_id,
+        source_company_key: undefined,
         contact_id: q.contact_id ?? undefined,
         mode: (q.mode ?? "ocean") as QuoteMode,
         service_type: q.service_type ?? undefined,
@@ -151,7 +161,10 @@ function reducer(state: BuilderState, action: Action): BuilderState {
 /** Strip the editable state down to the create/update input the edge fn wants. */
 function toInput(state: BuilderState): QuoteCreateInput {
   return {
+    // Send both — the server resolves source_company_key → a real company UUID
+    // when company_id is absent (or a non-UUID slug slips through).
     company_id: state.company_id,
+    source_company_key: state.source_company_key,
     contact_id: state.contact_id,
     mode: state.mode,
     service_type: state.service_type,
@@ -205,7 +218,11 @@ export default function QuoteBuilder() {
     initialState(companyIdParam),
   );
   const [company, setCompany] = useState<AttachedCompany | null>(
-    companyIdParam ? { company_id: companyIdParam, company_name: "Company" } : null,
+    companyIdParam
+      ? isUuid(companyIdParam)
+        ? { company_id: companyIdParam, company_name: "Company" }
+        : { source_company_key: companyIdParam, company_name: "Company" }
+      : null,
   );
 
   const [quoteNumber, setQuoteNumber] = useState<string | null>(null);
@@ -283,8 +300,8 @@ export default function QuoteBuilder() {
    * the Save button and as the save-first step of Generate PDF.
    */
   async function saveQuote(): Promise<Quote | null> {
-    if (!state.company_id) {
-      setSaveError("Attach a company before saving.");
+    if (!state.company_id && !state.source_company_key) {
+      setSaveError("Select a company first.");
       return null;
     }
     setSaving(true);
@@ -513,7 +530,14 @@ export default function QuoteBuilder() {
               company={company}
               onSelect={(c) => {
                 setCompany(c);
-                patch({ company_id: c.company_id });
+                // A UUID is a real internal company; otherwise it's a source
+                // slug the server resolves on save. Clear the other field so we
+                // never send a stale value.
+                if (isUuid(c.company_id)) {
+                  patch({ company_id: c.company_id, source_company_key: undefined });
+                } else {
+                  patch({ source_company_key: c.source_company_key, company_id: undefined });
+                }
               }}
             />
           </LitSectionCard>

--- a/frontend/src/features/quoting/QuoteBuilder.tsx
+++ b/frontend/src/features/quoting/QuoteBuilder.tsx
@@ -242,6 +242,14 @@ export default function QuoteBuilder() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
+  // --- Auto-mileage (domestic lanes only) ---------------------------------
+  // Once the user types in the Distance field we stop auto-overriding it.
+  const distanceManuallyEdited = useRef(false);
+  // Monotonic guard so a slow earlier request can't clobber a newer one.
+  const distanceReqSeq = useRef(0);
+  const [distanceCalcing, setDistanceCalcing] = useState(false);
+  const [autoDistanceSource, setAutoDistanceSource] = useState<string | null>(null);
+
   // Hydrate an existing quote.
   useEffect(() => {
     if (!quoteId) return;
@@ -254,6 +262,9 @@ export default function QuoteBuilder() {
         if (cancelled) return;
         const { quote, line_items, company: co } = res.data;
         dispatch({ type: "hydrate", quote, line_items: line_items ?? [] });
+        // A saved quote with a distance is treated as user-owned; don't
+        // auto-override it on load.
+        if (quote.distance_miles != null) distanceManuallyEdited.current = true;
         setQuoteNumber(quote.quote_number);
         setStatus(quote.status);
         setServerTotals(totalsFromQuote(quote));
@@ -293,6 +304,59 @@ export default function QuoteBuilder() {
   const totals = serverTotals ?? liveTotals;
 
   const laneValue: LaneFields = state;
+
+  // Domestic modes drive a road-miles lookup; ocean/air have no mileage.
+  const isDomesticMode = state.mode === "ftl" || state.mode === "ltl" || state.mode === "drayage";
+  // Mode-aware origin/destination strings for geocoding. For ftl/ltl the lane
+  // fields write to the city columns; drayage origin is a port/ramp (city-ish)
+  // string and its destination is an address kept in the city column.
+  const autoOrigin = (state.mode === "drayage" ? state.origin_port : state.origin_city) ?? "";
+  const autoDestination = state.destination_city ?? "";
+
+  // Debounced auto-mileage. Fires ~700ms after both endpoints are non-empty,
+  // skips when the user has manually edited the distance, and ignores stale
+  // responses via a monotonic request id.
+  useEffect(() => {
+    if (!isDomesticMode) return;
+    if (distanceManuallyEdited.current) return;
+    const origin = autoOrigin.trim();
+    const destination = autoDestination.trim();
+    if (origin.length < 2 || destination.length < 2) return;
+
+    const seq = ++distanceReqSeq.current;
+    const handle = setTimeout(() => {
+      setDistanceCalcing(true);
+      quoting
+        .distance(origin, destination)
+        .then((res) => {
+          if (seq !== distanceReqSeq.current) return; // stale
+          if (distanceManuallyEdited.current) return; // user took over mid-flight
+          if (typeof res.miles === "number") {
+            setAutoDistanceSource(res.source ?? "osrm");
+            patch({ distance_miles: res.miles });
+          }
+          // res.miles === null → leave the field for manual entry; never fake a number.
+        })
+        .catch(() => {
+          // Network/edge failure: silently leave the field for manual entry.
+        })
+        .finally(() => {
+          if (seq === distanceReqSeq.current) setDistanceCalcing(false);
+        });
+    }, 700);
+
+    return () => clearTimeout(handle);
+  }, [isDomesticMode, autoOrigin, autoDestination]);
+
+  // Manual edit of the Distance field: stop auto-calc from overriding it and
+  // drop the "Auto" hint.
+  function patchDistanceManual(distance_miles: number | undefined) {
+    distanceManuallyEdited.current = true;
+    distanceReqSeq.current++; // invalidate any in-flight auto request
+    setDistanceCalcing(false);
+    setAutoDistanceSource(null);
+    patch({ distance_miles });
+  }
 
   /**
    * Persist the quote and return the server-authoritative Quote. Returns null
@@ -376,6 +440,18 @@ export default function QuoteBuilder() {
   function setLineItems(items: QuoteLineItem[]) {
     setServerTotals(null);
     dispatch({ type: "setLineItems", items });
+  }
+
+  // Patch from the lane form. A direct edit to its Distance (mi) input counts
+  // as a manual override, same as the dedicated field below.
+  function patchLane(p: Partial<BuilderState>) {
+    if ("distance_miles" in p) {
+      patchDistanceManual(p.distance_miles);
+      const { distance_miles, ...rest } = p;
+      if (Object.keys(rest).length) patch(rest);
+    } else {
+      patch(p);
+    }
   }
 
   const lane = useMemo(() => laneSummary(state), [state]);
@@ -543,7 +619,7 @@ export default function QuoteBuilder() {
           </LitSectionCard>
 
           <LitSectionCard title="Lane & Shipment Details" collapsible defaultOpen>
-            <QuoteLaneShipmentForm value={laneValue} onChange={patch} />
+            <QuoteLaneShipmentForm value={laneValue} onChange={patchLane} />
           </LitSectionCard>
 
           <LitSectionCard title="Line Items & Accessorials" collapsible defaultOpen padded={false}>
@@ -558,12 +634,20 @@ export default function QuoteBuilder() {
                 <FieldLabel label="Distance (mi)" mono>
                   <input
                     value={state.distance_miles == null ? "" : String(state.distance_miles)}
-                    onChange={(e) =>
-                      patch({ distance_miles: toNum(e.target.value) })
-                    }
+                    onChange={(e) => patchDistanceManual(toNum(e.target.value))}
                     inputMode="decimal"
                     className={inputMono}
                   />
+                  {distanceCalcing ? (
+                    <span className="mt-1 inline-flex items-center gap-1 text-[10.5px] font-medium text-slate-400">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Calculating…
+                    </span>
+                  ) : autoDistanceSource && !distanceManuallyEdited.current ? (
+                    <span className="mt-1 text-[10.5px] font-medium text-cyan-700">
+                      Auto (via {autoDistanceSource})
+                    </span>
+                  ) : null}
                 </FieldLabel>
                 <FieldLabel label="Fuel Surcharge %" mono>
                   <input

--- a/frontend/src/features/quoting/QuoteBuilder.tsx
+++ b/frontend/src/features/quoting/QuoteBuilder.tsx
@@ -35,6 +35,7 @@ import {
   type QuoteMode,
   type QuoteStatus,
   type QuoteCreateInput,
+  type QuoteSettings,
 } from "@/api/quoting";
 import { computeTotals, type QuoteTotals } from "@/lib/quoting/totals";
 import LitSectionCard from "@/components/ui/LitSectionCard";
@@ -230,6 +231,9 @@ export default function QuoteBuilder() {
   const [serverTotals, setServerTotals] = useState<QuoteTotals | null>(null);
   // Last server-authoritative Quote — the source for PDF generation + send.
   const [savedQuote, setSavedQuote] = useState<Quote | null>(null);
+  // Org quote settings (branding + defaults). Loaded once; drives NEW-quote
+  // prefill and is passed to the PDF exporter for logo/signature/terms.
+  const [orgSettings, setOrgSettings] = useState<QuoteSettings | null>(null);
 
   // PDF state.
   const [pdfSignedUrl, setPdfSignedUrl] = useState<string | null>(null);
@@ -293,6 +297,45 @@ export default function QuoteBuilder() {
       cancelled = true;
     };
   }, [quoteId]);
+
+  // Load org quote settings once. On a NEW quote (no :quoteId) prefill the
+  // defaults that are still empty — never clobbering values the user already
+  // typed. For an existing quote we still load settings (for the PDF) but skip
+  // prefill so the saved quote's own values stand.
+  const settingsAppliedRef = useRef(false);
+  useEffect(() => {
+    if (settingsAppliedRef.current) return;
+    settingsAppliedRef.current = true;
+    let cancelled = false;
+    quoting
+      .settingsGet()
+      .then((res) => {
+        if (cancelled) return;
+        const s = res.data.settings ?? {};
+        setOrgSettings(s);
+        if (quoteId) return; // existing quote: don't prefill
+        const fill: Partial<BuilderState> = {};
+        // Only fill where the current state hasn't been set yet.
+        if ((state.currency === "USD" || !state.currency) && s.default_currency) {
+          fill.currency = s.default_currency;
+        }
+        if (state.fuel_surcharge_pct == null && s.default_fuel_surcharge_pct != null) {
+          fill.fuel_surcharge_pct = s.default_fuel_surcharge_pct;
+        }
+        if (!state.terms_text && s.terms_text) {
+          fill.terms_text = s.terms_text;
+        }
+        if (Object.keys(fill).length) patch(fill);
+      })
+      .catch(() => {
+        // Settings are best-effort prefill; a failure leaves manual entry.
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount; `state`/`patch` reads are intentional snapshots.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Live local totals — server is authoritative on save, but this drives the
   // panel on every keystroke.
@@ -421,6 +464,7 @@ export default function QuoteBuilder() {
         return;
       }
       const dataUri = await exportQuotePdf(quote, state.line_items, {
+        settings: orgSettings,
         companyName: company?.company_name ?? null,
       });
       const res = await quoting.generatePdf(quote.id, dataUri);

--- a/frontend/src/features/quoting/QuoteBuilder.tsx
+++ b/frontend/src/features/quoting/QuoteBuilder.tsx
@@ -22,7 +22,11 @@ import {
   Send,
   CheckCircle2,
   Loader2,
+  Lock,
+  Sparkles,
 } from "lucide-react";
+import { Link } from "react-router-dom";
+import { useEntitlements } from "@/hooks/useEntitlements";
 
 import {
   quoting,
@@ -189,6 +193,10 @@ function laneSummary(s: BuilderState): string {
 
 export default function QuoteBuilder() {
   const navigate = useNavigate();
+  const { entitlements, isAdmin } = useEntitlements();
+  // Gate persist/PDF/send ONLY when the server explicitly disables quoting.
+  // Viewing/editing the form stays open; the server re-checks on every write.
+  const quotingLocked = !isAdmin && entitlements?.features?.quoting === false;
   const { quoteId } = useParams<{ quoteId: string }>();
   const [searchParams] = useSearchParams();
   const companyIdParam = searchParams.get("company_id") ?? undefined;
@@ -431,8 +439,9 @@ export default function QuoteBuilder() {
           <button
             type="button"
             onClick={handleSave}
-            disabled={saving}
-            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] border border-slate-200 bg-white px-4 font-display text-[13px] font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60 sm:flex-none"
+            disabled={saving || quotingLocked}
+            title={quotingLocked ? "Upgrade to Growth to save quotes" : undefined}
+            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] border border-slate-200 bg-white px-4 font-display text-[13px] font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60 disabled:cursor-not-allowed sm:flex-none"
           >
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
             Save Draft
@@ -440,8 +449,9 @@ export default function QuoteBuilder() {
           <button
             type="button"
             onClick={handleGeneratePdf}
-            disabled={generatingPdf || saving}
-            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] px-4 font-display text-[13px] font-semibold text-white transition disabled:opacity-60 sm:flex-none"
+            disabled={generatingPdf || saving || quotingLocked}
+            title={quotingLocked ? "Upgrade to Growth to generate PDFs" : undefined}
+            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] px-4 font-display text-[13px] font-semibold text-white transition disabled:opacity-60 disabled:cursor-not-allowed sm:flex-none"
             style={{ background: "linear-gradient(180deg,#0891b2,#0e7490)" }}
           >
             {generatingPdf ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
@@ -450,7 +460,9 @@ export default function QuoteBuilder() {
           <button
             type="button"
             onClick={scrollToSend}
-            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] px-4 font-display text-[13px] font-semibold text-white transition hover:brightness-110 sm:flex-none"
+            disabled={quotingLocked}
+            title={quotingLocked ? "Upgrade to Growth to send quotes" : undefined}
+            className="inline-flex h-[38px] flex-1 items-center justify-center gap-2 rounded-[10px] px-4 font-display text-[13px] font-semibold text-white transition hover:brightness-110 disabled:opacity-60 disabled:cursor-not-allowed sm:flex-none"
             style={{ background: "linear-gradient(180deg,#2563eb,#1d4ed8)" }}
           >
             <Send className="h-4 w-4" />
@@ -458,6 +470,31 @@ export default function QuoteBuilder() {
           </button>
         </div>
       </div>
+
+      {quotingLocked && (
+        <div className="mx-auto mt-3 max-w-[1320px] px-4 sm:px-6">
+          <div className="flex flex-wrap items-center gap-3 rounded-[12px] border border-amber-200 bg-amber-50 px-4 py-3">
+            <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-[9px] bg-amber-100 text-amber-700">
+              <Lock className="h-4 w-4" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="font-display text-[13px] font-semibold text-amber-900">
+                Quoting is available on Growth and above.
+              </div>
+              <p className="text-[12.5px] text-amber-800">
+                Upgrade to create and send quotes.
+              </p>
+            </div>
+            <Link
+              to="/app/billing"
+              className="inline-flex h-9 flex-shrink-0 items-center gap-1.5 rounded-[10px] bg-amber-600 px-3.5 font-display text-[12.5px] font-semibold text-white transition hover:bg-amber-700"
+            >
+              <Sparkles className="h-4 w-4" />
+              Upgrade
+            </Link>
+          </div>
+        </div>
+      )}
 
       {saveError && (
         <div className="mx-auto mt-3 max-w-[1320px] px-4 sm:px-6">

--- a/frontend/src/features/quoting/QuoteSettings.tsx
+++ b/frontend/src/features/quoting/QuoteSettings.tsx
@@ -1,0 +1,541 @@
+/**
+ * QuoteSettings — the `/app/quoting/settings` page.
+ *
+ * Org-level quote branding + defaults editor. On mount it loads the saved
+ * settings via `quoting.settingsGet()` and seeds the form; any empty field
+ * falls back to org-derived starting values (org_name → company_name,
+ * org_logo_url → logo_url) so a first-time user immediately sees their
+ * workspace name + logo pre-filled (still editable + savable).
+ *
+ * Logo / signature uploads are resized client-side via a canvas to ≤360px on
+ * the long edge and exported as a PNG (or JPEG when the PNG is large) data-URI
+ * — that keeps every image well under the server's 700k-char cap.
+ *
+ * Saving is admin-only on the server: a non-admin save returns a FORBIDDEN
+ * EdgeFunctionError, which we surface inline and use to disable Save.
+ */
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft, Save, Loader2, CheckCircle2, ImageUp, X, Lock } from "lucide-react";
+
+import { quoting, type QuoteSettings as Settings } from "@/api/quoting";
+import { EdgeFunctionError } from "@/api/_client";
+import { useAuth } from "@/auth/AuthProvider";
+import LitSectionCard from "@/components/ui/LitSectionCard";
+
+const PAYMENT_TERMS_OPTIONS = [
+  "Net 30",
+  "Net 15",
+  "Net 45",
+  "Due on receipt",
+  "50% deposit, balance on delivery",
+];
+
+const CURRENCY_OPTIONS = ["USD", "CAD", "EUR", "GBP", "MXN"];
+
+const input =
+  "h-10 w-full rounded-[9px] border border-slate-200 bg-slate-50 px-3 text-[13px] text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-500/15 disabled:opacity-60 disabled:cursor-not-allowed";
+const textarea =
+  "w-full rounded-[9px] border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] leading-relaxed text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-500/15 disabled:opacity-60 disabled:cursor-not-allowed";
+
+/**
+ * Resize an image File to ≤`maxEdge` on its long edge and return a data-URI.
+ * Tries PNG first; if that comes back large (data-URIs balloon for photos),
+ * re-exports as JPEG at q0.82. Either way the result stays well under the
+ * server's 700k-char limit thanks to the dimension cap.
+ */
+function resizeImageToDataUrl(file: File, maxEdge = 360): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("Could not read the image file."));
+    reader.onload = () => {
+      const img = new Image();
+      img.onerror = () => reject(new Error("That file isn't a valid image."));
+      img.onload = () => {
+        const { width, height } = img;
+        if (!width || !height) {
+          reject(new Error("That image has no dimensions."));
+          return;
+        }
+        const scale = Math.min(1, maxEdge / Math.max(width, height));
+        const w = Math.max(1, Math.round(width * scale));
+        const h = Math.max(1, Math.round(height * scale));
+        const canvas = document.createElement("canvas");
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Canvas isn't available in this browser."));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, w, h);
+        let out = canvas.toDataURL("image/png");
+        // PNG of a photographic image can still be large — fall back to JPEG.
+        if (out.length > 600_000) {
+          out = canvas.toDataURL("image/jpeg", 0.82);
+        }
+        resolve(out);
+      };
+      img.src = String(reader.result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function QuoteSettings() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [form, setForm] = useState<Settings>({});
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  // Server-confirmed: non-admins can't save. Set true when a save 403s.
+  const [forbidden, setForbidden] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+
+  const logoInputRef = useRef<HTMLInputElement | null>(null);
+  const signatureInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    quoting
+      .settingsGet()
+      .then((res) => {
+        if (cancelled) return;
+        const s = res.data.settings ?? {};
+        const orgName = res.data.org_name ?? undefined;
+        const orgLogo = res.data.org_logo_url ?? undefined;
+        // Seed from saved settings; fall back to org-derived values for the
+        // two brandable fields when the saved value is empty.
+        setForm({
+          ...s,
+          company_name: s.company_name || orgName || "",
+          logo_url: s.logo_url || orgLogo || "",
+          prepared_by: s.prepared_by || (user?.displayName ?? "") || "",
+          default_currency: s.default_currency || "USD",
+        });
+      })
+      .catch((e) => {
+        if (!cancelled) setLoadError(e?.message ?? "Failed to load settings.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // user?.displayName is only a default seed; don't refetch when it resolves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function patch(p: Partial<Settings>) {
+    setSavedAt(null);
+    setForm((f) => ({ ...f, ...p }));
+  }
+
+  async function handleImage(
+    file: File | undefined,
+    key: "logo_url" | "signature_url",
+  ) {
+    if (!file) return;
+    setImageError(null);
+    try {
+      const dataUrl = await resizeImageToDataUrl(file);
+      patch({ [key]: dataUrl } as Partial<Settings>);
+    } catch (e: any) {
+      setImageError(e?.message ?? "Couldn't process that image.");
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError(null);
+    setImageError(null);
+    try {
+      // Drop empty strings so we don't persist blanks over org-derived values.
+      const payload: Settings = {};
+      (Object.keys(form) as (keyof Settings)[]).forEach((k) => {
+        const v = form[k];
+        if (v === "" || v == null) return;
+        (payload as any)[k] = v;
+      });
+      const res = await quoting.settingsUpdate(payload);
+      setForm((f) => ({ ...f, ...res.data.settings }));
+      setSavedAt(Date.now());
+    } catch (e: any) {
+      if (e instanceof EdgeFunctionError && e.code === "FORBIDDEN") {
+        setForbidden(true);
+        setSaveError("Only workspace owners/admins can edit quote branding.");
+      } else if (e instanceof EdgeFunctionError && e.code === "IMAGE_TOO_LARGE") {
+        setSaveError("Image too large, please use a smaller logo.");
+      } else {
+        setSaveError(e?.message ?? "Save failed.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid min-h-[60vh] place-items-center text-slate-400">
+        <div className="flex items-center gap-2 text-[13px]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading settings…
+        </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto max-w-md px-6 py-16 text-center">
+        <div className="text-[15px] font-bold text-slate-900">
+          Couldn&apos;t load quote settings
+        </div>
+        <p className="mt-1 text-[13px] text-slate-500">{loadError}</p>
+        <button
+          type="button"
+          onClick={() => navigate("/app/quoting")}
+          className="mt-5 inline-flex h-10 items-center rounded-[10px] border border-slate-200 bg-white px-4 text-[13px] font-semibold text-slate-700 hover:bg-slate-50"
+        >
+          Back to Quoting
+        </button>
+      </div>
+    );
+  }
+
+  const saveDisabled = saving || forbidden;
+
+  return (
+    <div className="min-h-full">
+      {/* Sticky action header */}
+      <div className="sticky top-0 z-30 flex flex-wrap items-center gap-3 border-b border-slate-200 bg-white/90 px-4 py-3 backdrop-blur sm:px-6">
+        <button
+          type="button"
+          onClick={() => navigate("/app/quoting")}
+          aria-label="Back to quoting"
+          className="grid h-9 w-9 flex-shrink-0 place-items-center rounded-[9px] border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50"
+        >
+          <ArrowLeft className="h-[18px] w-[18px]" />
+        </button>
+
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <h1 className="font-display text-[18px] font-bold tracking-[-0.3px] text-slate-900">
+            Quote Settings
+          </h1>
+          <small className="truncate text-[12px] text-slate-500">
+            Branding &amp; defaults applied to every new quote and PDF.
+          </small>
+        </div>
+
+        <div className="ml-auto flex w-full items-center gap-2 sm:w-auto">
+          {savedAt && !saving && (
+            <span className="hidden items-center gap-1.5 text-[12px] text-slate-400 sm:inline-flex">
+              <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+              Saved
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saveDisabled}
+            title={forbidden ? "Only workspace owners/admins can edit quote branding." : undefined}
+            className="inline-flex h-[38px] w-full items-center justify-center gap-2 rounded-[10px] px-4 font-display text-[13px] font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+            style={{ background: "linear-gradient(180deg,#2563eb,#1d4ed8)" }}
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            Save Settings
+          </button>
+        </div>
+      </div>
+
+      {forbidden && (
+        <div className="mx-auto mt-3 max-w-[760px] px-4 sm:px-6">
+          <div className="flex flex-wrap items-center gap-3 rounded-[12px] border border-amber-200 bg-amber-50 px-4 py-3">
+            <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-[9px] bg-amber-100 text-amber-700">
+              <Lock className="h-4 w-4" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="font-display text-[13px] font-semibold text-amber-900">
+                Read-only access
+              </div>
+              <p className="text-[12.5px] text-amber-800">
+                Only workspace owners/admins can edit quote branding.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {saveError && !forbidden && (
+        <div className="mx-auto mt-3 max-w-[760px] px-4 sm:px-6">
+          <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-[12.5px] text-rose-700">
+            {saveError}
+          </div>
+        </div>
+      )}
+
+      <div className="mx-auto flex max-w-[760px] flex-col gap-4 px-4 py-5 pb-20 sm:px-6">
+        {/* Company */}
+        <LitSectionCard title="Company">
+          <div className="space-y-3">
+            <Field label="Company Name">
+              <input
+                value={form.company_name ?? ""}
+                onChange={(e) => patch({ company_name: e.target.value })}
+                placeholder="Your company name"
+                className={input}
+                disabled={forbidden}
+              />
+            </Field>
+            <Field label="Address">
+              <textarea
+                value={form.company_address ?? ""}
+                onChange={(e) => patch({ company_address: e.target.value })}
+                rows={2}
+                placeholder="Street, City, State ZIP, Country"
+                className={textarea}
+                disabled={forbidden}
+              />
+            </Field>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label="Email">
+                <input
+                  type="email"
+                  value={form.company_email ?? ""}
+                  onChange={(e) => patch({ company_email: e.target.value })}
+                  placeholder="quotes@company.com"
+                  className={input}
+                  disabled={forbidden}
+                />
+              </Field>
+              <Field label="Phone">
+                <input
+                  value={form.company_phone ?? ""}
+                  onChange={(e) => patch({ company_phone: e.target.value })}
+                  placeholder="+1 (555) 000-0000"
+                  className={input}
+                  disabled={forbidden}
+                />
+              </Field>
+            </div>
+          </div>
+        </LitSectionCard>
+
+        {/* Logo */}
+        <LitSectionCard title="Logo" sub="Shown in the header of every quote PDF.">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+            <div className="grid h-24 w-44 flex-shrink-0 place-items-center overflow-hidden rounded-[10px] border border-dashed border-slate-200 bg-slate-50">
+              {form.logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={form.logo_url}
+                  alt="Logo preview"
+                  className="max-h-full max-w-full object-contain"
+                />
+              ) : (
+                <span className="text-[11px] text-slate-400">No logo</span>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <input
+                ref={logoInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                  void handleImage(e.target.files?.[0], "logo_url");
+                  e.target.value = "";
+                }}
+              />
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => logoInputRef.current?.click()}
+                  disabled={forbidden}
+                  className="inline-flex h-9 items-center gap-2 rounded-[9px] border border-slate-200 bg-white px-3 text-[12.5px] font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <ImageUp className="h-4 w-4" />
+                  {form.logo_url ? "Replace logo" : "Upload logo"}
+                </button>
+                {form.logo_url && (
+                  <button
+                    type="button"
+                    onClick={() => patch({ logo_url: "" })}
+                    disabled={forbidden}
+                    className="inline-flex h-9 items-center gap-1.5 rounded-[9px] border border-slate-200 bg-white px-3 text-[12.5px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <X className="h-4 w-4" />
+                    Clear
+                  </button>
+                )}
+              </div>
+              <p className="text-[11.5px] text-slate-400">
+                PNG or JPEG. Resized automatically to fit the PDF header.
+              </p>
+            </div>
+          </div>
+        </LitSectionCard>
+
+        {/* Signature */}
+        <LitSectionCard title="Signature" sub="Appears above the prepared-by line on the PDF.">
+          <div className="space-y-3">
+            <Field label="Signature Name">
+              <input
+                value={form.signature_name ?? ""}
+                onChange={(e) => patch({ signature_name: e.target.value })}
+                placeholder="Jane Doe"
+                className={input}
+                disabled={forbidden}
+              />
+            </Field>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+              <div className="grid h-20 w-44 flex-shrink-0 place-items-center overflow-hidden rounded-[10px] border border-dashed border-slate-200 bg-slate-50">
+                {form.signature_url ? (
+                  <img
+                    src={form.signature_url}
+                    alt="Signature preview"
+                    className="max-h-full max-w-full object-contain"
+                  />
+                ) : (
+                  <span className="text-[11px] text-slate-400">No signature</span>
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <input
+                  ref={signatureInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    void handleImage(e.target.files?.[0], "signature_url");
+                    e.target.value = "";
+                  }}
+                />
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => signatureInputRef.current?.click()}
+                    disabled={forbidden}
+                    className="inline-flex h-9 items-center gap-2 rounded-[9px] border border-slate-200 bg-white px-3 text-[12.5px] font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <ImageUp className="h-4 w-4" />
+                    {form.signature_url ? "Replace signature" : "Upload signature"}
+                  </button>
+                  {form.signature_url && (
+                    <button
+                      type="button"
+                      onClick={() => patch({ signature_url: "" })}
+                      disabled={forbidden}
+                      className="inline-flex h-9 items-center gap-1.5 rounded-[9px] border border-slate-200 bg-white px-3 text-[12.5px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <X className="h-4 w-4" />
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+            <Field label="Prepared By">
+              <input
+                value={form.prepared_by ?? ""}
+                onChange={(e) => patch({ prepared_by: e.target.value })}
+                placeholder="Your name"
+                className={input}
+                disabled={forbidden}
+              />
+            </Field>
+          </div>
+        </LitSectionCard>
+
+        {imageError && (
+          <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-[12.5px] text-rose-700">
+            {imageError}
+          </div>
+        )}
+
+        {/* Defaults */}
+        <LitSectionCard title="Quote Defaults" sub="Applied to each new quote (you can override per quote).">
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label="Default Payment Terms">
+                <select
+                  value={form.default_payment_terms ?? ""}
+                  onChange={(e) => patch({ default_payment_terms: e.target.value })}
+                  className={input}
+                  disabled={forbidden}
+                >
+                  <option value="">— Select —</option>
+                  {PAYMENT_TERMS_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Default Currency">
+                <select
+                  value={form.default_currency ?? "USD"}
+                  onChange={(e) => patch({ default_currency: e.target.value })}
+                  className={input}
+                  disabled={forbidden}
+                >
+                  {CURRENCY_OPTIONS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+            </div>
+            <Field label="Default Fuel Surcharge %">
+              <input
+                value={form.default_fuel_surcharge_pct == null ? "" : String(form.default_fuel_surcharge_pct)}
+                onChange={(e) => {
+                  const v = e.target.value.trim();
+                  if (v === "") {
+                    patch({ default_fuel_surcharge_pct: undefined });
+                    return;
+                  }
+                  const n = Number(v);
+                  if (Number.isFinite(n)) patch({ default_fuel_surcharge_pct: n });
+                }}
+                inputMode="decimal"
+                placeholder="e.g. 12.5"
+                className={input + " max-w-[200px] font-mono font-semibold"}
+                disabled={forbidden}
+              />
+            </Field>
+            <Field label="Terms & Conditions">
+              <textarea
+                value={form.terms_text ?? ""}
+                onChange={(e) => patch({ terms_text: e.target.value })}
+                rows={4}
+                placeholder="Rates exclude duties & taxes. Subject to space & equipment availability…"
+                className={textarea}
+                disabled={forbidden}
+              />
+            </Field>
+          </div>
+        </LitSectionCard>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="font-display text-[10px] font-bold uppercase tracking-[0.06em] text-slate-400">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/features/quoting/QuotingDashboard.tsx
+++ b/frontend/src/features/quoting/QuotingDashboard.tsx
@@ -30,6 +30,7 @@ import {
   Copy,
   FileText,
   Sparkles,
+  Settings as SettingsIcon,
 } from "lucide-react";
 
 import { quoting } from "@/api/quoting";
@@ -160,38 +161,49 @@ export default function QuotingDashboard() {
             Turn freight intelligence into priced, sent, and tracked revenue.
           </p>
         </div>
-        {quotingLocked ? (
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <button
             type="button"
-            onClick={() => navigate("/app/billing")}
-            title="Upgrade to Growth to create quotes"
-            className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
-            style={{
-              fontFamily: "'Space Grotesk', sans-serif",
-              background: "linear-gradient(180deg,#d97706,#b45309)",
-              boxShadow:
-                "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)",
-            }}
+            onClick={() => navigate("/app/quoting/settings")}
+            aria-label="Quote settings"
+            title="Quote settings"
+            className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-[10px] border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-900"
           >
-            <Sparkles className="w-4 h-4" />
-            Upgrade to create quotes
+            <SettingsIcon className="w-[18px] h-[18px]" />
           </button>
-        ) : (
-          <button
-            type="button"
-            onClick={() => navigate("/app/quoting/new")}
-            className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
-            style={{
-              fontFamily: "'Space Grotesk', sans-serif",
-              background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
-              boxShadow:
-                "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
-            }}
-          >
-            <Plus className="w-4 h-4" />
-            New Quote
-          </button>
-        )}
+          {quotingLocked ? (
+            <button
+              type="button"
+              onClick={() => navigate("/app/billing")}
+              title="Upgrade to Growth to create quotes"
+              className="inline-flex items-center justify-center gap-2 h-10 flex-1 sm:flex-none sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
+              style={{
+                fontFamily: "'Space Grotesk', sans-serif",
+                background: "linear-gradient(180deg,#d97706,#b45309)",
+                boxShadow:
+                  "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+              }}
+            >
+              <Sparkles className="w-4 h-4" />
+              Upgrade to create quotes
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => navigate("/app/quoting/new")}
+              className="inline-flex items-center justify-center gap-2 h-10 flex-1 sm:flex-none sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
+              style={{
+                fontFamily: "'Space Grotesk', sans-serif",
+                background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
+                boxShadow:
+                  "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+              }}
+            >
+              <Plus className="w-4 h-4" />
+              New Quote
+            </button>
+          )}
+        </div>
       </div>
 
       {/* KPI row */}

--- a/frontend/src/features/quoting/QuotingDashboard.tsx
+++ b/frontend/src/features/quoting/QuotingDashboard.tsx
@@ -29,9 +29,11 @@ import {
   Eye,
   Copy,
   FileText,
+  Sparkles,
 } from "lucide-react";
 
 import { quoting } from "@/api/quoting";
+import { useEntitlements } from "@/hooks/useEntitlements";
 import type { QuoteStatus, QuoteListItem, QuoteMode } from "@/api/quoting";
 import EnhancedKpiCard from "@/components/dashboard/EnhancedKpiCard";
 import LitSectionCard from "@/components/ui/LitSectionCard";
@@ -88,6 +90,10 @@ function formatMargin(pct?: number | null): string {
 
 export default function QuotingDashboard() {
   const navigate = useNavigate();
+  const { entitlements, isAdmin } = useEntitlements();
+  // Viewing the dashboard (KPIs + list) is allowed on every plan; only the
+  // "New Quote" CTA is gated when the server explicitly disables quoting.
+  const quotingLocked = !isAdmin && entitlements?.features?.quoting === false;
   const [filter, setFilter] = useState<FilterKey>("all");
 
   const activeTab = FILTER_TABS.find((t) => t.key === filter) ?? FILTER_TABS[0];
@@ -154,20 +160,38 @@ export default function QuotingDashboard() {
             Turn freight intelligence into priced, sent, and tracked revenue.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => navigate("/app/quoting/new")}
-          className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
-          style={{
-            fontFamily: "'Space Grotesk', sans-serif",
-            background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
-            boxShadow:
-              "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
-          }}
-        >
-          <Plus className="w-4 h-4" />
-          New Quote
-        </button>
+        {quotingLocked ? (
+          <button
+            type="button"
+            onClick={() => navigate("/app/billing")}
+            title="Upgrade to Growth to create quotes"
+            className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
+            style={{
+              fontFamily: "'Space Grotesk', sans-serif",
+              background: "linear-gradient(180deg,#d97706,#b45309)",
+              boxShadow:
+                "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+            }}
+          >
+            <Sparkles className="w-4 h-4" />
+            Upgrade to create quotes
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => navigate("/app/quoting/new")}
+            className="inline-flex items-center justify-center gap-2 h-10 w-full sm:w-auto px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
+            style={{
+              fontFamily: "'Space Grotesk', sans-serif",
+              background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
+              boxShadow:
+                "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+            }}
+          >
+            <Plus className="w-4 h-4" />
+            New Quote
+          </button>
+        )}
       </div>
 
       {/* KPI row */}
@@ -222,7 +246,12 @@ export default function QuotingDashboard() {
         {listQuery.isLoading ? (
           <QuotesSkeleton />
         ) : quotes.length === 0 ? (
-          <EmptyState onNew={() => navigate("/app/quoting/new")} />
+          <EmptyState
+            locked={quotingLocked}
+            onNew={() =>
+              navigate(quotingLocked ? "/app/billing" : "/app/quoting/new")
+            }
+          />
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full border-collapse">
@@ -432,7 +461,7 @@ function QuotesSkeleton() {
   );
 }
 
-function EmptyState({ onNew }: { onNew: () => void }) {
+function EmptyState({ onNew, locked = false }: { onNew: () => void; locked?: boolean }) {
   return (
     <div className="flex flex-col items-center justify-center text-center px-6 py-14">
       <div className="w-12 h-12 rounded-xl bg-slate-100 grid place-items-center mb-4">
@@ -445,21 +474,27 @@ function EmptyState({ onNew }: { onNew: () => void }) {
         No quotes yet
       </div>
       <p className="text-[13px] text-slate-500 mt-1 max-w-sm">
-        Create your first quote to start pricing, sending, and tracking revenue.
+        {locked
+          ? "Quoting is available on Growth and above. Upgrade to start pricing, sending, and tracking revenue."
+          : "Create your first quote to start pricing, sending, and tracking revenue."}
       </p>
       <button
         type="button"
         onClick={onNew}
+        title={locked ? "Upgrade to Growth to create quotes" : undefined}
         className="mt-5 inline-flex items-center justify-center gap-2 h-10 px-4 rounded-[10px] text-[13.5px] font-semibold text-white transition hover:brightness-105"
         style={{
           fontFamily: "'Space Grotesk', sans-serif",
-          background: "linear-gradient(180deg,#2563eb,#1d4ed8)",
-          boxShadow:
-            "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
+          background: locked
+            ? "linear-gradient(180deg,#d97706,#b45309)"
+            : "linear-gradient(180deg,#2563eb,#1d4ed8)",
+          boxShadow: locked
+            ? "0 6px 16px rgba(217,119,6,.28), inset 0 1px 0 rgba(255,255,255,.18)"
+            : "0 6px 16px rgba(37,99,235,.28), inset 0 1px 0 rgba(255,255,255,.18)",
         }}
       >
-        <Plus className="w-4 h-4" />
-        New Quote
+        {locked ? <Sparkles className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+        {locked ? "Upgrade to create quotes" : "New Quote"}
       </button>
     </div>
   );

--- a/frontend/src/features/quoting/components/LocationAutocomplete.tsx
+++ b/frontend/src/features/quoting/components/LocationAutocomplete.tsx
@@ -1,0 +1,263 @@
+/**
+ * LocationAutocomplete — assistive type-ahead for US city/state/zip fields.
+ *
+ * Uses Photon (komoot's free OSM autocomplete — no API key, CORS-enabled,
+ * callable directly from the browser). Suggestions are assistive only: the
+ * field still works as a plain text input, and Photon downtime can never break
+ * the form (fetch failures are swallowed and simply show no suggestions).
+ *
+ * Drop-in replacement for the lane-form city <input>: it writes the same string
+ * via onChange so downstream effects (e.g. auto-mileage) keep working.
+ */
+import { useEffect, useRef, useState } from "react";
+
+interface PhotonProps {
+  name?: string;
+  city?: string;
+  state?: string;
+  postcode?: string;
+  countrycode?: string;
+}
+
+interface PhotonFeature {
+  properties?: PhotonProps;
+  geometry?: { coordinates?: [number, number] };
+}
+
+/** Full US state/territory name → 2-letter abbreviation (50 states + DC). */
+const STATE_ABBR: Record<string, string> = {
+  Alabama: "AL",
+  Alaska: "AK",
+  Arizona: "AZ",
+  Arkansas: "AR",
+  California: "CA",
+  Colorado: "CO",
+  Connecticut: "CT",
+  Delaware: "DE",
+  "District of Columbia": "DC",
+  Florida: "FL",
+  Georgia: "GA",
+  Hawaii: "HI",
+  Idaho: "ID",
+  Illinois: "IL",
+  Indiana: "IN",
+  Iowa: "IA",
+  Kansas: "KS",
+  Kentucky: "KY",
+  Louisiana: "LA",
+  Maine: "ME",
+  Maryland: "MD",
+  Massachusetts: "MA",
+  Michigan: "MI",
+  Minnesota: "MN",
+  Mississippi: "MS",
+  Missouri: "MO",
+  Montana: "MT",
+  Nebraska: "NE",
+  Nevada: "NV",
+  "New Hampshire": "NH",
+  "New Jersey": "NJ",
+  "New Mexico": "NM",
+  "New York": "NY",
+  "North Carolina": "NC",
+  "North Dakota": "ND",
+  Ohio: "OH",
+  Oklahoma: "OK",
+  Oregon: "OR",
+  Pennsylvania: "PA",
+  "Rhode Island": "RI",
+  "South Carolina": "SC",
+  "South Dakota": "SD",
+  Tennessee: "TN",
+  Texas: "TX",
+  Utah: "UT",
+  Vermont: "VT",
+  Virginia: "VA",
+  Washington: "WA",
+  "West Virginia": "WV",
+  Wisconsin: "WI",
+  Wyoming: "WY",
+};
+
+function formatLabel(props: PhotonProps): string {
+  const city = props.city || props.name || "";
+  const st = STATE_ABBR[props.state ?? ""] ?? props.state ?? "";
+  const zip = props.postcode ?? "";
+  return [city, [st, zip].filter(Boolean).join(" ")].filter(Boolean).join(", ");
+}
+
+const inputCls =
+  "h-10 w-full rounded-[9px] border border-slate-200 bg-slate-50 px-3 text-[13px] text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-500/15";
+
+export interface LocationAutocompleteProps {
+  value: string;
+  onChange: (text: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function LocationAutocomplete({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  className,
+}: LocationAutocompleteProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [highlight, setHighlight] = useState(-1);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  // Monotonic request id — only the latest query's response is allowed to win.
+  const reqIdRef = useRef(0);
+  // Suppress the next fetch after a programmatic select (so picking a suggestion
+  // doesn't immediately re-open the dropdown).
+  const skipNextRef = useRef(false);
+
+  // Debounced Photon fetch keyed on `value`.
+  useEffect(() => {
+    if (skipNextRef.current) {
+      skipNextRef.current = false;
+      return;
+    }
+    const q = value.trim();
+    if (q.length < 3) {
+      setSuggestions([]);
+      setLoading(false);
+      return;
+    }
+
+    const reqId = ++reqIdRef.current;
+    setLoading(true);
+    const t = setTimeout(() => {
+      const url =
+        "https://photon.komoot.io/api/?q=" +
+        encodeURIComponent(q) +
+        "&limit=6&lang=en";
+      fetch(url)
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error("bad status"))))
+        .then((data: { features?: PhotonFeature[] }) => {
+          // Stale-response guard: ignore anything but the latest request.
+          if (reqId !== reqIdRef.current) return;
+          const labels: string[] = [];
+          const seen = new Set<string>();
+          for (const f of data.features ?? []) {
+            const props = f.properties;
+            if (!props || props.countrycode !== "US") continue;
+            const label = formatLabel(props);
+            if (!label || seen.has(label)) continue;
+            seen.add(label);
+            labels.push(label);
+            if (labels.length >= 6) break;
+          }
+          setSuggestions(labels);
+          setHighlight(-1);
+          setOpen(true);
+          setLoading(false);
+        })
+        .catch(() => {
+          // Graceful degradation: swallow errors, show no suggestions.
+          if (reqId !== reqIdRef.current) return;
+          setSuggestions([]);
+          setLoading(false);
+        });
+    }, 250);
+
+    return () => clearTimeout(t);
+  }, [value]);
+
+  // Click-outside closes the dropdown.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const select = (label: string) => {
+    skipNextRef.current = true;
+    onChange(label);
+    setSuggestions([]);
+    setOpen(false);
+    setHighlight(-1);
+  };
+
+  const showDropdown = open && (loading || suggestions.length > 0);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showDropdown) {
+      if (e.key === "ArrowDown" && suggestions.length > 0) {
+        setOpen(true);
+        setHighlight(0);
+        e.preventDefault();
+      }
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => (h + 1 >= suggestions.length ? 0 : h + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => (h - 1 < 0 ? suggestions.length - 1 : h - 1));
+    } else if (e.key === "Enter") {
+      if (highlight >= 0 && highlight < suggestions.length) {
+        e.preventDefault();
+        select(suggestions[highlight]);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setHighlight(-1);
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <input
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => {
+          if (suggestions.length > 0) setOpen(true);
+        }}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className ?? inputCls}
+        autoComplete="off"
+      />
+      {showDropdown && (
+        <ul className="absolute left-0 right-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-[9px] border border-slate-200 bg-white py-1 shadow-lg">
+          {loading && suggestions.length === 0 && (
+            <li className="px-3 py-2 text-[13px] text-slate-400">Searching…</li>
+          )}
+          {suggestions.map((s, i) => (
+            <li
+              key={s}
+              // onMouseDown (not onClick) so selection fires before the input's
+              // blur, keeping the click reliable.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(s);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              className={
+                "cursor-pointer px-3 py-2 text-[13px] text-slate-900 " +
+                (i === highlight ? "bg-blue-50 text-blue-700" : "hover:bg-slate-50")
+              }
+            >
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
+++ b/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
@@ -6,8 +6,10 @@
  * display it (logo, name, domain, contact) with a "Change" affordance.
  *
  * FALLBACK path: no company attached → a minimal search box backed by the
- * existing `searchCompanies` proxy (`frontend/src/lib/api.ts`). Picking a result
- * emits `{ company_id, company_name, domain }` up to the builder.
+ * Supabase-native `quote-company-search` edge function (over `lit_company_index`).
+ * Picking a result emits `{ source_company_key, company_name }` up to the
+ * builder — the source key is an ImportYeti slug, NOT an internal UUID, so the
+ * server resolves it to a real `lit_companies.id` on save.
  */
 import { useEffect, useRef, useState } from "react";
 import {
@@ -20,11 +22,11 @@ import {
   Loader2,
   RotateCw,
 } from "lucide-react";
-import { searchCompanies, type CompanyHit } from "@/lib/api";
-import { parseLimitExceeded } from "@/lib/usage";
+import { quoting, type CompanySearchHit } from "@/api/quoting";
 
 export interface AttachedCompany {
-  company_id: string;
+  company_id?: string;
+  source_company_key?: string;
   company_name: string;
   domain?: string | null;
   /** Real ImportYeti shipment volume — used by the revenue-opportunity panel. */
@@ -142,14 +144,16 @@ function CompanySearch({
   onCancel?: () => void;
 }) {
   const [q, setQ] = useState("");
-  const [rows, setRows] = useState<CompanyHit[]>([]);
+  const [rows, setRows] = useState<CompanySearchHit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Bumped by the Retry button to re-run the effect for the current query.
   const [retryNonce, setRetryNonce] = useState(0);
-  const abortRef = useRef<AbortController | null>(null);
+  // Monotonic request id so a slow earlier response can't overwrite a newer one
+  // (the edge invoke has no AbortController/signal support).
+  const reqRef = useRef(0);
 
-  // Debounced search against the existing companies proxy.
+  // Debounced search against the Supabase-native `quote-company-search` fn.
   // TODO: richer company search (filters, contacts) — Phase 1 keeps this minimal.
   useEffect(() => {
     const term = q.trim();
@@ -161,31 +165,26 @@ function CompanySearch({
     setLoading(true);
     setError(null);
     const t = setTimeout(async () => {
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
+      const myReq = ++reqRef.current;
       try {
-        const res = await searchCompanies({ q: term, limit: 8 }, ctrl.signal);
-        setRows(res.rows ?? []);
+        const res = await quoting.companySearch(term);
+        if (myReq !== reqRef.current) return;
+        setRows(res.items ?? []);
       } catch (e: any) {
-        if (ctrl.signal.aborted) return;
-        // Distinguish a plan-limit gate (403 LIMIT_EXCEEDED) and a backend
-        // outage (5xx / network) from a generic failure — mirrors how
-        // AddCompanyModal surfaces the search-credit limit.
+        if (myReq !== reqRef.current) return;
+        // It's a Supabase edge fn now — a generic "temporarily unavailable +
+        // retry" message covers transport/5xx/OK_FALSE. Keep a 403 branch in
+        // case a future gate surfaces a plan limit via code/status.
+        const code: string | undefined = e?.code;
         const status: number | undefined = e?.status;
-        if (status === 403) {
-          // Quota gate. We surface a static plan-limit message; parse the
-          // body so a future copy tweak can show used/limit if present.
-          parseLimitExceeded(e?.body);
+        if (status === 403 || code === "FORBIDDEN" || code === "LIMIT_EXCEEDED") {
           setError("Company search limit reached on your plan.");
-        } else if (status == null || status >= 500) {
-          setError("Search is temporarily unavailable. Please retry.");
         } else {
-          setError("Search failed. Try again.");
+          setError("Search is temporarily unavailable. Please retry.");
         }
         setRows([]);
       } finally {
-        if (!ctrl.signal.aborted) setLoading(false);
+        if (myReq === reqRef.current) setLoading(false);
       }
     }, 300);
     return () => clearTimeout(t);
@@ -226,36 +225,40 @@ function CompanySearch({
 
       {rows.length > 0 && (
         <div className="mt-3 max-h-72 divide-y divide-slate-100 overflow-y-auto rounded-[10px] border border-slate-200">
-          {rows.map((r) => (
-            <button
-              key={r.company_id}
-              type="button"
-              onClick={() =>
-                onSelect({
-                  company_id: r.company_id,
-                  company_name: r.company_name,
-                  domain: r.domain,
-                  shipments_12m: r.shipments_12m,
-                  top_routes: r.top_routes,
-                  address: r.address,
-                })
-              }
-              className="flex w-full min-h-[44px] items-center gap-3 px-3 py-2.5 text-left transition hover:bg-slate-50"
-            >
-              <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-md bg-slate-100 text-[11px] font-bold text-slate-600">
-                {initials(r.company_name)}
-              </div>
-              <div className="min-w-0">
-                <div className="truncate text-[13px] font-semibold text-slate-900">
-                  {r.company_name}
+          {rows.map((r) => {
+            const place = [r.city, r.country].filter(Boolean).join(", ");
+            const subtitle = [
+              place || null,
+              r.total_shipments != null ? `${r.total_shipments.toLocaleString()} shipments` : null,
+            ]
+              .filter(Boolean)
+              .join(" · ");
+            return (
+              <button
+                key={r.source_company_key}
+                type="button"
+                onClick={() =>
+                  onSelect({
+                    // No company_id here — the source key is an ImportYeti slug,
+                    // not an internal UUID. The server resolves it on save.
+                    source_company_key: r.source_company_key,
+                    company_name: r.company_name,
+                  })
+                }
+                className="flex w-full min-h-[44px] items-center gap-3 px-3 py-2.5 text-left transition hover:bg-slate-50"
+              >
+                <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-md bg-slate-100 text-[11px] font-bold text-slate-600">
+                  {initials(r.company_name)}
                 </div>
-                <div className="truncate text-[11px] text-slate-400">
-                  {r.domain ?? "—"}
-                  {r.shipments_12m != null ? ` · ${r.shipments_12m.toLocaleString()} shp/12M` : ""}
+                <div className="min-w-0">
+                  <div className="truncate text-[13px] font-semibold text-slate-900">
+                    {r.company_name}
+                  </div>
+                  <div className="truncate text-[11px] text-slate-400">{subtitle || "—"}</div>
                 </div>
-              </div>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
+++ b/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
@@ -10,8 +10,18 @@
  * emits `{ company_id, company_name, domain }` up to the builder.
  */
 import { useEffect, useRef, useState } from "react";
-import { Building2, Globe, MapPin, User, Repeat, Search, Loader2 } from "lucide-react";
+import {
+  Building2,
+  Globe,
+  MapPin,
+  User,
+  Repeat,
+  Search,
+  Loader2,
+  RotateCw,
+} from "lucide-react";
 import { searchCompanies, type CompanyHit } from "@/lib/api";
+import { parseLimitExceeded } from "@/lib/usage";
 
 export interface AttachedCompany {
   company_id: string;
@@ -135,6 +145,8 @@ function CompanySearch({
   const [rows, setRows] = useState<CompanyHit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Bumped by the Retry button to re-run the effect for the current query.
+  const [retryNonce, setRetryNonce] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
 
   // Debounced search against the existing companies proxy.
@@ -155,17 +167,29 @@ function CompanySearch({
       try {
         const res = await searchCompanies({ q: term, limit: 8 }, ctrl.signal);
         setRows(res.rows ?? []);
-      } catch (e) {
-        if (!ctrl.signal.aborted) {
+      } catch (e: any) {
+        if (ctrl.signal.aborted) return;
+        // Distinguish a plan-limit gate (403 LIMIT_EXCEEDED) and a backend
+        // outage (5xx / network) from a generic failure — mirrors how
+        // AddCompanyModal surfaces the search-credit limit.
+        const status: number | undefined = e?.status;
+        if (status === 403) {
+          // Quota gate. We surface a static plan-limit message; parse the
+          // body so a future copy tweak can show used/limit if present.
+          parseLimitExceeded(e?.body);
+          setError("Company search limit reached on your plan.");
+        } else if (status == null || status >= 500) {
+          setError("Search is temporarily unavailable. Please retry.");
+        } else {
           setError("Search failed. Try again.");
-          setRows([]);
         }
+        setRows([]);
       } finally {
         if (!ctrl.signal.aborted) setLoading(false);
       }
     }, 300);
     return () => clearTimeout(t);
-  }, [q]);
+  }, [q, retryNonce]);
 
   return (
     <div>
@@ -186,7 +210,19 @@ function CompanySearch({
           Searching…
         </div>
       )}
-      {error && <div className="mt-3 px-1 text-[12px] text-rose-600">{error}</div>}
+      {error && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 px-1 text-[12px] text-rose-600">
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => setRetryNonce((n) => n + 1)}
+            className="inline-flex h-7 items-center gap-1 rounded-[8px] border border-rose-200 bg-white px-2 font-semibold text-rose-700 transition hover:bg-rose-50"
+          >
+            <RotateCw className="h-3 w-3" />
+            Retry
+          </button>
+        </div>
+      )}
 
       {rows.length > 0 && (
         <div className="mt-3 max-h-72 divide-y divide-slate-100 overflow-y-auto rounded-[10px] border border-slate-200">

--- a/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
+++ b/frontend/src/features/quoting/components/QuoteCompanySelector.tsx
@@ -6,12 +6,14 @@
  * display it (logo, name, domain, contact) with a "Change" affordance.
  *
  * FALLBACK path: no company attached → a minimal search box backed by the
- * Supabase-native `quote-company-search` edge function (over `lit_company_index`).
- * Picking a result emits `{ source_company_key, company_name }` up to the
- * builder — the source key is an ImportYeti slug, NOT an internal UUID, so the
- * server resolves it to a real `lit_companies.id` on save.
+ * Supabase-native `quote-company-search` edge function. Per the product rule, a
+ * user may only quote companies they've SAVED to their org's Command Center, so
+ * the search is scoped to `lit_saved_companies` (NOT the global index). Each hit
+ * already carries the internal `lit_companies.id` UUID, so picking a result
+ * emits `{ company_id, company_name }` — no slug resolution needed on save.
  */
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Building2,
   Globe,
@@ -198,7 +200,7 @@ function CompanySearch({
           autoFocus
           value={q}
           onChange={(e) => setQ(e.target.value)}
-          placeholder="Search companies by name…"
+          placeholder="Search your saved companies…"
           className="h-10 w-full rounded-[9px] border border-slate-200 bg-slate-50 pl-9 pr-3 text-[13px] text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-500/15"
         />
       </div>
@@ -229,19 +231,19 @@ function CompanySearch({
             const place = [r.city, r.country].filter(Boolean).join(", ");
             const subtitle = [
               place || null,
-              r.total_shipments != null ? `${r.total_shipments.toLocaleString()} shipments` : null,
+              r.shipments_12m != null ? `${r.shipments_12m.toLocaleString()} shipments` : null,
             ]
               .filter(Boolean)
               .join(" · ");
             return (
               <button
-                key={r.source_company_key}
+                key={r.company_id}
                 type="button"
                 onClick={() =>
                   onSelect({
-                    // No company_id here — the source key is an ImportYeti slug,
-                    // not an internal UUID. The server resolves it on save.
-                    source_company_key: r.source_company_key,
+                    // Saved companies carry a real internal lit_companies UUID —
+                    // pass it through directly; no slug resolution on save.
+                    company_id: r.company_id,
                     company_name: r.company_name,
                   })
                 }
@@ -263,15 +265,19 @@ function CompanySearch({
       )}
 
       {!loading && q.trim().length >= 2 && rows.length === 0 && !error && (
-        <div className="mt-3 px-1 text-[12px] text-slate-400">
-          No companies found for “{q.trim()}”.
+        <div className="mt-3 px-1 text-[12px] text-slate-500">
+          No saved companies match “{q.trim()}”.{" "}
+          <Link to="/app/search" className="font-semibold text-blue-600 hover:text-blue-700">
+            Save companies from Search &amp; Intel
+          </Link>{" "}
+          to quote them.
         </div>
       )}
 
       {q.trim().length < 2 && (
         <div className="mt-3 flex items-start gap-2 px-1 text-[12px] text-slate-400">
           <Building2 className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
-          Type at least 2 characters to search your company index.
+          Type at least 2 characters to search your saved companies.
         </div>
       )}
 

--- a/frontend/src/features/quoting/components/QuoteLaneShipmentForm.tsx
+++ b/frontend/src/features/quoting/components/QuoteLaneShipmentForm.tsx
@@ -13,6 +13,7 @@
  */
 import { Ship, Plane, Truck, Container } from "lucide-react";
 import type { QuoteMode } from "@/api/quoting";
+import LocationAutocomplete from "./LocationAutocomplete";
 import {
   SERVICE_TYPES,
   CATEGORY,
@@ -153,32 +154,37 @@ export default function QuoteLaneShipmentForm({
       {/* Origin / Destination */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <Field label={cfg.originLabel}>
-          <input
-            value={originVal ?? ""}
-            onChange={(e) =>
-              onChange(
-                originIsPort
-                  ? { origin_port: e.target.value }
-                  : { origin_city: e.target.value },
-              )
-            }
-            className={inputCls}
-            placeholder={cfg.originLabel}
-          />
+          {originIsPort ? (
+            // Port / ramp / airport: city autocomplete doesn't fit port codes.
+            <input
+              value={originVal ?? ""}
+              onChange={(e) => onChange({ origin_port: e.target.value })}
+              className={inputCls}
+              placeholder={cfg.originLabel}
+            />
+          ) : (
+            <LocationAutocomplete
+              value={originVal ?? ""}
+              onChange={(v) => onChange({ origin_city: v })}
+              placeholder={cfg.originLabel}
+            />
+          )}
         </Field>
         <Field label={cfg.destLabel}>
-          <input
-            value={destVal ?? ""}
-            onChange={(e) =>
-              onChange(
-                destIsPort
-                  ? { destination_port: e.target.value }
-                  : { destination_city: e.target.value },
-              )
-            }
-            className={inputCls}
-            placeholder={cfg.destLabel}
-          />
+          {destIsPort ? (
+            <input
+              value={destVal ?? ""}
+              onChange={(e) => onChange({ destination_port: e.target.value })}
+              className={inputCls}
+              placeholder={cfg.destLabel}
+            />
+          ) : (
+            <LocationAutocomplete
+              value={destVal ?? ""}
+              onChange={(v) => onChange({ destination_city: v })}
+              placeholder={cfg.destLabel}
+            />
+          )}
         </Field>
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -979,7 +979,15 @@ export async function searchCompanies(
   });
 
   if (!response.ok) {
-    throw new Error(`search ${response.status}`);
+    // Carry the HTTP status (and, for 403, the parsed limit body) so callers
+    // can distinguish a plan-limit gate (403 LIMIT_EXCEEDED) from a backend
+    // outage (5xx) instead of collapsing everything into one generic message.
+    const err: any = new Error(`search_${response.status}`);
+    err.status = response.status;
+    if (response.status === 403) {
+      err.body = await response.json().catch(() => null);
+    }
+    throw err;
   }
 
   const data = await response.json().catch(() => ({}));

--- a/frontend/src/lib/quoting/exportQuotePdf.ts
+++ b/frontend/src/lib/quoting/exportQuotePdf.ts
@@ -14,7 +14,7 @@
 import jsPDF from "jspdf";
 import autoTable, { type RowInput } from "jspdf-autotable";
 
-import type { Quote, QuoteLineItem, QuoteMode } from "@/api/quoting";
+import type { Quote, QuoteLineItem, QuoteMode, QuoteSettings } from "@/api/quoting";
 import { USES_PORTS } from "@/lib/quoting/modeFields";
 import { BRAND, PDF_PAGE } from "@/lib/pulse/reportBrand";
 
@@ -56,11 +56,59 @@ export interface QuoteOrgDefaults {
 
 export interface ExportQuotePdfOptions {
   orgDefaults?: QuoteOrgDefaults | null;
+  /** Full org quote settings (branding + defaults). Supersedes `orgDefaults`. */
+  settings?: QuoteSettings | null;
   /** Optional human-readable company name for the customer block. */
   companyName?: string | null;
   /** Optional contact name for the customer block. */
   contactName?: string | null;
   generatedAt?: Date;
+}
+
+/**
+ * Merge the full `settings` object (new path) with the legacy `orgDefaults`
+ * shape so the rest of the renderer reads one normalized object. `settings`
+ * wins; `orgDefaults` fields are a fallback for older callers.
+ */
+function resolveBranding(opts: ExportQuotePdfOptions): QuoteSettings {
+  const s = opts.settings ?? {};
+  const d = opts.orgDefaults ?? {};
+  return {
+    company_name: s.company_name ?? d.company_name ?? undefined,
+    company_address: s.company_address ?? undefined,
+    company_email: s.company_email ?? undefined,
+    company_phone: s.company_phone ?? undefined,
+    logo_url: s.logo_url ?? undefined,
+    signature_url: s.signature_url ?? undefined,
+    signature_name: s.signature_name ?? d.signature_name ?? undefined,
+    prepared_by: s.prepared_by ?? d.prepared_by ?? undefined,
+    default_payment_terms: s.default_payment_terms ?? d.payment_terms ?? undefined,
+    terms_text: s.terms_text ?? d.terms_text ?? undefined,
+  };
+}
+
+/**
+ * Load a (data-URI) image and resolve its natural pixel dimensions so the PDF
+ * can preserve aspect ratio when placing it. Resolves to null on any failure
+ * so callers can fall back to the text brand mark — never throws.
+ */
+function loadImageSize(dataUrl: string): Promise<{ w: number; h: number } | null> {
+  return new Promise((resolve) => {
+    try {
+      const img = new Image();
+      img.onload = () =>
+        resolve(img.naturalWidth && img.naturalHeight ? { w: img.naturalWidth, h: img.naturalHeight } : null);
+      img.onerror = () => resolve(null);
+      img.src = dataUrl;
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/** Map a data-URI mime to a jsPDF image format token. */
+function imageFormat(dataUrl: string): "PNG" | "JPEG" {
+  return /^data:image\/jpe?g/i.test(dataUrl) ? "JPEG" : "PNG";
 }
 
 // ─── Formatting helpers ────────────────────────────────────────────────────
@@ -129,12 +177,62 @@ function drawBrandMark(doc: jsPDF, x: number, y: number, size: number): void {
 }
 
 // ─── Page chrome ───────────────────────────────────────────────────────────
-function drawHeaderBar(doc: jsPDF, orgName: string): void {
+/** Pre-resolved logo placement so the per-page chrome stamp stays synchronous. */
+interface LogoPlacement {
+  dataUrl: string;
+  fmt: "PNG" | "JPEG";
+  w: number;
+  h: number;
+}
+
+/**
+ * Compute a logo placement (scaled to ≤`maxH` header height, aspect preserved)
+ * from a data-URI. Returns null when the image can't be sized — caller falls
+ * back to the text brand mark.
+ */
+async function resolveLogoPlacement(
+  dataUrl: string | undefined | null,
+  maxH = 32,
+  maxW = 150,
+): Promise<LogoPlacement | null> {
+  if (!dataUrl) return null;
+  const size = await loadImageSize(dataUrl);
+  if (!size) return null;
+  const scale = Math.min(maxH / size.h, maxW / size.w);
+  return {
+    dataUrl,
+    fmt: imageFormat(dataUrl),
+    w: Math.max(1, size.w * scale),
+    h: Math.max(1, size.h * scale),
+  };
+}
+
+function drawHeaderBar(doc: jsPDF, orgName: string, logo: LogoPlacement | null): void {
   doc.setFillColor(...WHITE);
   doc.rect(0, 0, PAGE_W, HEADER_H, "F");
   doc.setDrawColor(...INK_200);
   doc.setLineWidth(0.5);
   doc.line(0, HEADER_H, PAGE_W, HEADER_H);
+
+  if (logo) {
+    // Vertically center the logo within the header band; name sits to its right.
+    const y = (HEADER_H - logo.h) / 2;
+    try {
+      doc.addImage(logo.dataUrl, logo.fmt, MARGIN, y, logo.w, logo.h);
+    } catch {
+      drawBrandMark(doc, MARGIN, 14, 28);
+    }
+    const textX = MARGIN + logo.w + 12;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(...INK_900);
+    doc.text(orgName, textX, 27);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(8);
+    doc.setTextColor(...INK_500);
+    doc.text("FREIGHT QUOTATION", textX, 39);
+    return;
+  }
 
   drawBrandMark(doc, MARGIN, 14, 28);
 
@@ -168,11 +266,11 @@ function drawFooter(doc: jsPDF, pageNum: number, pageCount: number): void {
   doc.text(right, PAGE_W - MARGIN - rw, barY + 11);
 }
 
-function stampPageChrome(doc: jsPDF, orgName: string): void {
+function stampPageChrome(doc: jsPDF, orgName: string, logo: LogoPlacement | null): void {
   const total = doc.getNumberOfPages();
   for (let i = 1; i <= total; i++) {
     doc.setPage(i);
-    drawHeaderBar(doc, orgName);
+    drawHeaderBar(doc, orgName, logo);
     drawFooter(doc, i, total);
   }
 }
@@ -207,6 +305,7 @@ function drawTitleBlock(
   doc: jsPDF,
   quote: Quote,
   opts: ExportQuotePdfOptions,
+  branding: QuoteSettings,
   startY: number,
 ): number {
   let y = startY;
@@ -215,6 +314,34 @@ function drawTitleBlock(
   doc.setFontSize(22);
   doc.setTextColor(...INK_900);
   doc.text("QUOTATION", MARGIN, y);
+  y += 6;
+
+  // Issuing-company block under the title (name + contact lines). Each field
+  // is optional and guarded; nothing renders when all are empty.
+  const companyName = clean(branding.company_name);
+  const contactLines = [
+    clean(branding.company_address),
+    [clean(branding.company_email), clean(branding.company_phone)].filter(Boolean).join("  ·  "),
+  ].filter(Boolean);
+
+  if (companyName) {
+    y += 10;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10.5);
+    doc.setTextColor(...INK_800);
+    doc.text(companyName, MARGIN, y);
+  }
+  if (contactLines.length) {
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(8.5);
+    doc.setTextColor(...INK_500);
+    for (const block of contactLines) {
+      for (const line of doc.splitTextToSize(block, CONTENT_W * 0.55)) {
+        y += 12;
+        doc.text(line, MARGIN, y);
+      }
+    }
+  }
 
   // Meta card top-right: quote #, date, valid-until.
   const generated = opts.generatedAt ?? (quote.created_at ? new Date(quote.created_at) : new Date());
@@ -451,16 +578,20 @@ function drawTotals(doc: jsPDF, quote: Quote, startY: number): number {
 function drawTermsAndSignature(
   doc: jsPDF,
   quote: Quote,
-  opts: ExportQuotePdfOptions,
+  branding: QuoteSettings,
+  signature: LogoPlacement | null,
   startY: number,
 ): number {
-  const defaults = opts.orgDefaults ?? {};
   let y = drawSectionHeader(doc, "Terms & Conditions", startY);
 
-  const paymentTerms = clean(defaults.payment_terms) || "Payment due Net 30 from invoice date.";
+  // Payment terms: org default first, then quote-specific override fallback.
+  const paymentTerms =
+    clean(branding.default_payment_terms) || "Payment due Net 30 from invoice date.";
+  // Terms text: the quote's own terms win (per-quote override), then the org
+  // default, then a sane boilerplate.
   const termsText =
-    clean(defaults.terms_text) ||
     clean(quote.terms_text) ||
+    clean(branding.terms_text) ||
     "Rates exclude duties & taxes. Subject to space & equipment availability. This quotation is valid until the date noted above.";
 
   doc.setFont("helvetica", "bold");
@@ -486,10 +617,21 @@ function drawTermsAndSignature(
   }
 
   // Prepared by + signature line.
-  y = ensureRoom(doc, y, 60);
+  y = ensureRoom(doc, y, signature ? 90 : 60);
   y += 14;
-  const preparedBy = clean(defaults.prepared_by) || clean(defaults.signature_name);
-  const orgName = clean(defaults.company_name) || BRAND.wordmark;
+  const preparedBy = clean(branding.prepared_by) || clean(branding.signature_name);
+  const signatureName = clean(branding.signature_name);
+  const orgName = clean(branding.company_name) || BRAND.wordmark;
+
+  // Draw the signature image (if any) sitting on the prepared-by line.
+  if (signature) {
+    try {
+      const sigY = y + 18 - signature.h; // baseline-aligned to the rule below
+      doc.addImage(signature.dataUrl, signature.fmt, MARGIN, Math.max(y, sigY), signature.w, signature.h);
+    } catch {
+      // Drawing failed — silently skip the image; the text block still renders.
+    }
+  }
 
   doc.setDrawColor(...INK_300);
   doc.setLineWidth(0.6);
@@ -501,12 +643,14 @@ function drawTermsAndSignature(
   doc.setFont("helvetica", "bold");
   doc.setFontSize(10);
   doc.setTextColor(...INK_900);
-  doc.text(preparedBy || orgName, MARGIN, y + 14);
-  if (preparedBy) {
+  doc.text(signatureName || preparedBy || orgName, MARGIN, y + 30);
+  // Secondary line: show the prepared-by name (or org) under the signed name.
+  const secondary = signatureName ? preparedBy || orgName : preparedBy ? orgName : "";
+  if (secondary) {
     doc.setFont("helvetica", "normal");
     doc.setFontSize(8.5);
     doc.setTextColor(...INK_500);
-    doc.text(orgName, MARGIN, y + 30);
+    doc.text(secondary, MARGIN, y + 44);
   }
 
   doc.setFont("helvetica", "bold");
@@ -520,7 +664,7 @@ function drawTermsAndSignature(
   doc.setTextColor(...INK_400);
   doc.text("Signature / Date", MARGIN + 300, y + 28);
 
-  return y + 36;
+  return y + 52;
 }
 
 // ─── Public entry point ────────────────────────────────────────────────────
@@ -538,10 +682,19 @@ export async function exportQuotePdf(
   doc.setFillColor(...WHITE);
   doc.rect(0, 0, PAGE_W, PAGE_H, "F");
 
-  const orgName = clean(opts.orgDefaults?.company_name) || BRAND.wordmark;
+  const branding = resolveBranding(opts);
+  const orgName = clean(branding.company_name) || BRAND.wordmark;
+
+  // Pre-load image dimensions up-front (async) so the synchronous draw passes
+  // — including the per-page chrome stamp — can place them with correct aspect
+  // ratio. Either resolve to null on failure → text fallbacks kick in.
+  const [logo, signature] = await Promise.all([
+    resolveLogoPlacement(branding.logo_url, 32, 150),
+    resolveLogoPlacement(branding.signature_url, 30, 180),
+  ]);
 
   let y = HEADER_H + 30;
-  y = drawTitleBlock(doc, quote, opts, y);
+  y = drawTitleBlock(doc, quote, opts, branding, y);
   y = drawCustomerAndLane(doc, quote, opts, y + 6);
 
   y = ensureRoom(doc, y, 120);
@@ -551,9 +704,9 @@ export async function exportQuotePdf(
   y = drawTotals(doc, quote, y);
 
   y = ensureRoom(doc, y, 140);
-  drawTermsAndSignature(doc, quote, opts, y + 8);
+  drawTermsAndSignature(doc, quote, branding, signature, y + 8);
 
-  stampPageChrome(doc, orgName);
+  stampPageChrome(doc, orgName, logo);
 
   return doc.output("datauristring");
 }

--- a/supabase/functions/_shared/quote_email.ts
+++ b/supabase/functions/_shared/quote_email.ts
@@ -212,15 +212,68 @@ export async function sendViaOutlook(
 }
 
 /**
- * Single entry point: refresh the token, pick the provider, send one email.
- * Gmail and Outlook only (the two OAuth mailbox providers). Resend is NOT
- * used here — quotes go through the user's own connected mailbox.
+ * Send a single HTML email through Resend (the connected system mailbox).
+ *
+ * Resend is API-key based — there is NO OAuth token to refresh. Mirrors the
+ * Resend send path in send-campaign-email's sendEmail(): same endpoint, bearer
+ * auth, `"Display Name <email>"` from-line, and message-id read (respJson.id).
+ * The account's own email is used as the verified sender + reply_to.
+ */
+export async function sendViaResend(
+  account: QuoteSenderAccount,
+  args: { to: string; toName?: string | null; subject: string; html: string },
+): Promise<{ ok: true; messageId: string | null } | { ok: false; error: string }> {
+  const apiKey = Deno.env.get("LIT_RESEND_API_KEY");
+  if (!apiKey) return { ok: false, error: "resend_not_configured" };
+
+  const { to, subject, html } = args;
+  const fromLine = `${account.display_name || "Logistic Intel"} <${account.email}>`;
+  try {
+    const resp = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: fromLine,
+        to: [to],
+        subject,
+        html,
+        reply_to: account.email,
+      }),
+    });
+    const respJson: { id?: string; message?: string; name?: string } = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      return { ok: false, error: `resend_${resp.status}:${respJson?.message || respJson?.name || ""}`.slice(0, 500) };
+    }
+    return { ok: true, messageId: respJson?.id ?? null };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "resend_threw" };
+  }
+}
+
+/**
+ * Single entry point: pick the provider, send one email.
+ *   - Gmail / Outlook: OAuth mailboxes — refresh the token, then send.
+ *   - Resend: the connected system mailbox (API key, no OAuth). Skips the
+ *     token path entirely.
  */
 export async function sendQuoteEmail(
   admin: SupabaseClient,
   account: QuoteSenderAccount,
   msg: { to: string; toName?: string | null; subject: string; html: string },
 ): Promise<{ ok: true; messageId: string | null } | { ok: false; error: string }> {
+  // Resend uses an API key, not OAuth — do NOT call getAccessToken.
+  if (account.provider === "resend") {
+    return await sendViaResend(account, {
+      to: msg.to,
+      toName: msg.toName,
+      subject: msg.subject,
+      html: msg.html,
+    });
+  }
+
   if (account.provider !== "gmail" && account.provider !== "outlook") {
     return { ok: false, error: `unsupported_provider:${account.provider}` };
   }

--- a/supabase/functions/_shared/quote_helpers.ts
+++ b/supabase/functions/_shared/quote_helpers.ts
@@ -20,6 +20,26 @@ export type LineItem = {
   is_accessorial?: boolean; taxable?: boolean; sort_order?: number;
 };
 
+/** Coerce a value to a number or null. Empty string / null / undefined / NaN → null.
+ *  Critical: form inputs send "" for untouched numeric fields, and Postgres rejects
+ *  "" for numeric columns. Use for every numeric quote column before insert/update. */
+export function numOrNull(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Coerce a numeric with a fallback (for line-item qty/cost that must not be null). */
+export function numOr(v: unknown, fallback: number): number {
+  const n = numOrNull(v);
+  return n === null ? fallback : n;
+}
+
+/** Empty string / null / undefined → null; otherwise pass through (for date/text-nullable cols). */
+export function emptyToNull<T>(v: T): T | null {
+  return v === "" || v === undefined || v === null ? null : v;
+}
+
 /** Recompute all quote financials from line items + fuel %. Server is source of truth. */
 export function computeTotals(items: LineItem[], fuelPct: number | null | undefined) {
   const num = (v: unknown) => (Number.isFinite(Number(v)) ? Number(v) : 0);

--- a/supabase/functions/quote-company-search/index.ts
+++ b/supabase/functions/quote-company-search/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { createLogger, requestId } from "../_shared/logger.ts";
+import { resolveOrg } from "../_shared/quote_helpers.ts";
 
 const cors = {
   "Access-Control-Allow-Origin": "*",
@@ -20,29 +21,47 @@ Deno.serve(async (req) => {
   const admin = createClient(url, svc);
   const { data: u } = await userClient.auth.getUser();
   if (!u?.user) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const userId = u.user.id;
 
-  // Search/view op over shared reference data (lit_company_index). Auth only —
-  // no org scoping and no quoting feature gate: the company index is not
-  // workspace-private, and the actual write boundary lives in quote-create.
+  // Product rule: a user may only quote companies they have SAVED to their org's
+  // Command Center. So this searches the org's saved companies (lit_saved_companies
+  // joined to lit_companies), NOT the global lit_company_index. Each hit already
+  // carries the internal lit_companies UUID — no slug linking needed downstream.
+  // Auth only — the real write boundary lives in quote-create.
   const body = await req.json().catch(() => ({}));
   const q = typeof body.q === "string" ? body.q.trim() : "";
   const limit = Math.min(20, Math.max(1, Number(body.limit) || 8));
   if (q.length < 2) return json({ ok: true, items: [] });
 
-  const { data, error } = await admin.from("lit_company_index")
-    .select("company_id, company_name, country, city, total_shipments, total_teu")
-    .ilike("company_name", `%${q}%`)
-    .order("total_shipments", { ascending: false, nullsFirst: false })
-    .limit(limit);
+  const orgId = await resolveOrg(admin, userId);
+  if (!orgId) return json({ ok: true, items: [] }); // no org → nothing saved to quote
+
+  // Org's saved companies, name-filtered via the embedded company table.
+  // Single FK (lit_saved_companies.company_id → lit_companies.id) makes the
+  // plain `lit_companies!inner(...)` embed unambiguous.
+  const { data, error } = await admin
+    .from("lit_saved_companies")
+    .select("company_id, lit_companies!inner(id, name, domain, city, state, country_code, shipments_12m)")
+    .eq("org_id", orgId)
+    .ilike("lit_companies.name", `%${q}%`)
+    .limit(50);
   if (error) { log.error("search_failed", { err: error.message }); return json({ ok: false, code: "SEARCH_FAILED" }, 500); }
 
-  const items = (data ?? []).map((r) => ({
-    source_company_key: r.company_id, // the slug → becomes lit_companies.source_company_key on link
-    company_name: r.company_name,
-    country: r.country ?? null,
-    city: r.city ?? null,
-    total_shipments: r.total_shipments ?? null,
-    total_teu: r.total_teu ?? null,
-  }));
+  const items = (data ?? [])
+    .map((r: any) => {
+      const c = r.lit_companies;
+      return c ? {
+        company_id: c.id,                 // internal UUID — already a real lit_companies row
+        company_name: c.name,
+        domain: c.domain ?? null,
+        city: c.city ?? null,
+        country: c.country_code ?? null,
+        shipments_12m: c.shipments_12m ?? null,
+      } : null;
+    })
+    .filter(Boolean)
+    .sort((a: any, b: any) => (b.shipments_12m ?? 0) - (a.shipments_12m ?? 0))
+    .slice(0, limit);
+
   return json({ ok: true, items });
 });

--- a/supabase/functions/quote-company-search/index.ts
+++ b/supabase/functions/quote-company-search/index.ts
@@ -1,0 +1,48 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createLogger, requestId } from "../_shared/logger.ts";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { ...cors, "Content-Type": "application/json" } });
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: cors });
+  if (req.method !== "POST") return json({ ok: false, code: "METHOD_NOT_ALLOWED" }, 405);
+  const log = createLogger("quote-company-search", { request_id: requestId() });
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const url = Deno.env.get("SUPABASE_URL")!, anon = Deno.env.get("SUPABASE_ANON_KEY")!, svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const userClient = createClient(url, anon, { global: { headers: { Authorization: auth } } });
+  const admin = createClient(url, svc);
+  const { data: u } = await userClient.auth.getUser();
+  if (!u?.user) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+
+  // Search/view op over shared reference data (lit_company_index). Auth only —
+  // no org scoping and no quoting feature gate: the company index is not
+  // workspace-private, and the actual write boundary lives in quote-create.
+  const body = await req.json().catch(() => ({}));
+  const q = typeof body.q === "string" ? body.q.trim() : "";
+  const limit = Math.min(20, Math.max(1, Number(body.limit) || 8));
+  if (q.length < 2) return json({ ok: true, items: [] });
+
+  const { data, error } = await admin.from("lit_company_index")
+    .select("company_id, company_name, country, city, total_shipments, total_teu")
+    .ilike("company_name", `%${q}%`)
+    .order("total_shipments", { ascending: false, nullsFirst: false })
+    .limit(limit);
+  if (error) { log.error("search_failed", { err: error.message }); return json({ ok: false, code: "SEARCH_FAILED" }, 500); }
+
+  const items = (data ?? []).map((r) => ({
+    source_company_key: r.company_id, // the slug → becomes lit_companies.source_company_key on link
+    company_name: r.company_name,
+    country: r.country ?? null,
+    city: r.city ?? null,
+    total_shipments: r.total_shipments ?? null,
+    total_teu: r.total_teu ?? null,
+  }));
+  return json({ ok: true, items });
+});

--- a/supabase/functions/quote-create/index.ts
+++ b/supabase/functions/quote-create/index.ts
@@ -29,14 +29,20 @@ Deno.serve(async (req) => {
   if (!gate.ok) return json(gate.body, gate.status);
 
   const body = await req.json().catch(() => ({}));
-  let companyId: string | null = body.company_id ?? null;
-  if (!companyId && body.source_company_key) {
+  // Defensive company resolution: the company search now returns ImportYeti
+  // slugs (e.g. "eae-usa") as source keys, NOT internal UUIDs. If a non-UUID
+  // sneaks in as company_id, treat it as a source key so we never try to use a
+  // slug as the lit_quotes.company_id FK (which would fail the FK constraint).
+  const isUuid = (v: unknown) => typeof v === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v);
+  let companyId: string | null = isUuid(body.company_id) ? body.company_id : null;
+  const sourceKey = body.source_company_key ?? (!isUuid(body.company_id) && body.company_id ? body.company_id : null);
+  if (!companyId && sourceKey) {
     const { data: existing } = await admin.from("lit_companies").select("id")
-      .eq("source_company_key", body.source_company_key).maybeSingle();
+      .eq("source_company_key", sourceKey).maybeSingle();
     if (existing) companyId = existing.id;
     else {
       const { data: created, error } = await admin.from("lit_companies")
-        .insert({ source: body.source ?? "importyeti", source_company_key: body.source_company_key, name: body.company_name ?? "Unknown" })
+        .insert({ source: body.source ?? "importyeti", source_company_key: sourceKey, name: body.company_name ?? "Unknown" })
         .select("id").single();
       if (error) { log.error("company_link_failed", { err: error.message }); return json({ ok: false, code: "COMPANY_LINK_FAILED" }, 500); }
       companyId = created.id;

--- a/supabase/functions/quote-create/index.ts
+++ b/supabase/functions/quote-create/index.ts
@@ -67,6 +67,7 @@ Deno.serve(async (req) => {
     distance_miles: numOrNull(body.distance_miles), equipment_type: body.equipment_type ?? null,
     container_count: numOrNull(body.container_count), weight_lbs: numOrNull(body.weight_lbs),
     volume_cbm: numOrNull(body.volume_cbm), pallet_count: numOrNull(body.pallet_count),
+    hazmat: body.hazmat === true || body.hazmat === "true", temp_controlled: body.temp_controlled === true || body.temp_controlled === "true",
     commodity: body.commodity ?? null, hs_code: body.hs_code ?? null, cargo_value: numOrNull(body.cargo_value),
     currency: body.currency ?? "USD", fuel_surcharge_pct: numOrNull(body.fuel_surcharge_pct),
     notes: body.notes ?? null, terms_text: body.terms_text ?? null, valid_until: emptyToNull(body.valid_until),

--- a/supabase/functions/quote-create/index.ts
+++ b/supabase/functions/quote-create/index.ts
@@ -1,6 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { createLogger, requestId } from "../_shared/logger.ts";
-import { resolveOrg, requireQuotingFeature, computeTotals, LineItem } from "../_shared/quote_helpers.ts";
+import { resolveOrg, requireQuotingFeature, computeTotals, LineItem, numOrNull, numOr, emptyToNull } from "../_shared/quote_helpers.ts";
 
 const cors = {
   "Access-Control-Allow-Origin": "*",
@@ -64,11 +64,12 @@ Deno.serve(async (req) => {
     origin_port: body.origin_port ?? null, destination_port: body.destination_port ?? null,
     origin_city: body.origin_city ?? null, origin_state: body.origin_state ?? null, origin_country: body.origin_country ?? null, origin_postal: body.origin_postal ?? null,
     destination_city: body.destination_city ?? null, destination_state: body.destination_state ?? null, destination_country: body.destination_country ?? null, destination_postal: body.destination_postal ?? null,
-    distance_miles: body.distance_miles ?? null, equipment_type: body.equipment_type ?? null,
-    container_count: body.container_count ?? null, weight_lbs: body.weight_lbs ?? null,
-    commodity: body.commodity ?? null, hs_code: body.hs_code ?? null, cargo_value: body.cargo_value ?? null,
-    currency: body.currency ?? "USD", fuel_surcharge_pct: body.fuel_surcharge_pct ?? null,
-    notes: body.notes ?? null, terms_text: body.terms_text ?? null, valid_until: body.valid_until ?? null,
+    distance_miles: numOrNull(body.distance_miles), equipment_type: body.equipment_type ?? null,
+    container_count: numOrNull(body.container_count), weight_lbs: numOrNull(body.weight_lbs),
+    volume_cbm: numOrNull(body.volume_cbm), pallet_count: numOrNull(body.pallet_count),
+    commodity: body.commodity ?? null, hs_code: body.hs_code ?? null, cargo_value: numOrNull(body.cargo_value),
+    currency: body.currency ?? "USD", fuel_surcharge_pct: numOrNull(body.fuel_surcharge_pct),
+    notes: body.notes ?? null, terms_text: body.terms_text ?? null, valid_until: emptyToNull(body.valid_until),
     ...totals,
   }).select("*").single();
   if (error) { log.error("insert_failed", { err: error.message }); return json({ ok: false, code: "INSERT_FAILED", message: error.message }, 500); }
@@ -76,7 +77,7 @@ Deno.serve(async (req) => {
   if (items.length) {
     const rows = items.map((li, i) => ({
       quote_id: quote.id, org_id: orgId, type: li.type ?? null, name: li.name, description: li.description ?? null,
-      unit: li.unit ?? null, quantity: li.quantity ?? 1, unit_cost: li.unit_cost ?? 0, unit_sell: li.unit_sell ?? 0,
+      unit: li.unit ?? null, quantity: numOr(li.quantity, 1), unit_cost: numOr(li.unit_cost, 0), unit_sell: numOr(li.unit_sell, 0),
       is_accessorial: !!li.is_accessorial, taxable: !!li.taxable, sort_order: li.sort_order ?? i,
     }));
     await admin.from("lit_quote_line_items").insert(rows);

--- a/supabase/functions/quote-distance/index.ts
+++ b/supabase/functions/quote-distance/index.ts
@@ -1,0 +1,115 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createLogger, requestId } from "../_shared/logger.ts";
+import { routeMiles, haversineMiles } from "../_shared/osrm_client.ts";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+const json = (b: unknown, s = 200) =>
+  new Response(JSON.stringify(b), { status: s, headers: { ...cors, "Content-Type": "application/json" } });
+
+interface GeoPoint {
+  lat: number;
+  lon: number;
+  label: string;
+}
+
+/**
+ * Geocode a free-text US location via OpenStreetMap Nominatim (free, no key).
+ * Returns null when no match is found. Throws on transport errors so the
+ * caller can decide how to surface them.
+ */
+async function geocode(query: string): Promise<GeoPoint | null> {
+  const url =
+    `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}` +
+    `&format=json&limit=1&countrycodes=us`;
+  const ctrl = new AbortController();
+  const tid = setTimeout(() => ctrl.abort(), 6000);
+  try {
+    const resp = await fetch(url, {
+      signal: ctrl.signal,
+      headers: {
+        "User-Agent": "LogisticIntel-Quoting/1.0 (support@logisticintel.com)",
+        "Accept": "application/json",
+      },
+    });
+    if (!resp.ok) throw new Error(`nominatim_${resp.status}`);
+    const arr = await resp.json();
+    const hit = Array.isArray(arr) ? arr[0] : null;
+    if (!hit) return null;
+    const lat = Number(hit.lat);
+    const lon = Number(hit.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    return { lat, lon, label: String(hit.display_name ?? query) };
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: cors });
+  if (req.method !== "POST") return json({ ok: false, code: "METHOD_NOT_ALLOWED" }, 405);
+  const log = createLogger("quote-distance", { request_id: requestId() });
+
+  // Auth only (no quoting-feature gate — distance is a low-cost utility).
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const url = Deno.env.get("SUPABASE_URL")!,
+    anon = Deno.env.get("SUPABASE_ANON_KEY")!;
+  const userClient = createClient(url, anon, { global: { headers: { Authorization: auth } } });
+  const { data: u } = await userClient.auth.getUser();
+  if (!u?.user) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+
+  const body = await req.json().catch(() => ({}));
+  const origin = String(body?.origin ?? "").trim();
+  const destination = String(body?.destination ?? "").trim();
+  if (origin.length < 2 || destination.length < 2) {
+    return json({ ok: true, miles: null, reason: "need_both" });
+  }
+
+  try {
+    // Sequential, not parallel — be polite to the free Nominatim endpoint.
+    const originGeo = await geocode(origin);
+    if (!originGeo) return json({ ok: true, miles: null, reason: "geocode_miss", which: "origin" });
+    const destGeo = await geocode(destination);
+    if (!destGeo) {
+      return json({ ok: true, miles: null, reason: "geocode_miss", which: "destination" });
+    }
+
+    // OSRM driving distance; routeMiles already falls back to haversine*1.2
+    // internally and reports which source it used.
+    let miles: number;
+    let source: "osrm" | "haversine";
+    try {
+      const route = await routeMiles({
+        fromLat: originGeo.lat,
+        fromLon: originGeo.lon,
+        toLat: destGeo.lat,
+        toLon: destGeo.lon,
+      });
+      miles = route.miles;
+      source = route.source;
+    } catch (routeErr) {
+      log.warn("route_failed_fallback_haversine", { err: String(routeErr) });
+      miles = haversineMiles(originGeo.lat, originGeo.lon, destGeo.lat, destGeo.lon);
+      source = "haversine";
+    }
+
+    if (!Number.isFinite(miles)) {
+      return json({ ok: true, miles: null, reason: "no_distance" });
+    }
+
+    return json({
+      ok: true,
+      miles: Math.round(miles),
+      source,
+      origin: { lat: originGeo.lat, lon: originGeo.lon, label: originGeo.label },
+      destination: { lat: destGeo.lat, lon: destGeo.lon, label: destGeo.label },
+    });
+  } catch (err) {
+    log.error("distance_failed", { err: err instanceof Error ? err.message : String(err) });
+    return json({ ok: false, code: "DISTANCE_FAILED" }, 500);
+  }
+});

--- a/supabase/functions/quote-send/index.ts
+++ b/supabase/functions/quote-send/index.ts
@@ -83,6 +83,26 @@ function defaultTemplate(opts: {
 </body></html>`;
 }
 
+// The secure-link CTA. ALWAYS appended to the outgoing email (even when the
+// sender supplies a custom message body) so the recipient always gets the link.
+function linkBlock(viewUrl: string): string {
+  return `<div style="max-width:560px;margin:8px auto 0;padding:0 24px 32px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
+    <a href="${esc(viewUrl)}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:12px 28px;border-radius:8px;">View your quote</a>
+    <p style="margin:14px 0 0;font-size:12px;color:#94a3b8;">If the button doesn't work, paste this link into your browser:<br/>
+      <a href="${esc(viewUrl)}" style="color:#2563eb;word-break:break-all;">${esc(viewUrl)}</a>
+    </p>
+  </div>`;
+}
+
+// Wrap a sender-edited plain-text body as HTML and append the secure link.
+function wrapUserBody(text: string, viewUrl: string): string {
+  const safe = esc(text).replace(/\r\n|\r|\n/g, "<br/>");
+  return `<!DOCTYPE html><html><body style="margin:0;padding:0;background:#f1f5f9;">
+  <div style="max-width:560px;margin:0 auto;padding:32px 24px 8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#0f172a;font-size:15px;line-height:1.5;">${safe}</div>
+  ${linkBlock(viewUrl)}
+</body></html>`;
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: cors });
   if (req.method !== "POST") return json({ ok: false, code: "METHOD_NOT_ALLOWED" }, 405);
@@ -179,7 +199,7 @@ Deno.serve(async (req) => {
   const subject = (body.subject ? String(body.subject) : "") || `Quote for ${lane} - ${companyName}`;
   const viewUrl = `${url}/functions/v1/quote-view?token=${quote.share_token}`;
   const html = (body.body && String(body.body).trim())
-    ? String(body.body)
+    ? wrapUserBody(String(body.body), viewUrl)
     : defaultTemplate({
         toName,
         lane,

--- a/supabase/functions/quote-settings-get/index.ts
+++ b/supabase/functions/quote-settings-get/index.ts
@@ -1,0 +1,35 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createLogger, requestId } from "../_shared/logger.ts";
+import { resolveOrg } from "../_shared/quote_helpers.ts";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { ...cors, "Content-Type": "application/json" } });
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: cors });
+  if (req.method !== "POST") return json({ ok: false, code: "METHOD_NOT_ALLOWED" }, 405);
+  const log = createLogger("quote-settings-get", { request_id: requestId() });
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const url = Deno.env.get("SUPABASE_URL")!, anon = Deno.env.get("SUPABASE_ANON_KEY")!, svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const userClient = createClient(url, anon, { global: { headers: { Authorization: auth } } });
+  const admin = createClient(url, svc);
+  const { data: u } = await userClient.auth.getUser();
+  if (!u?.user) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const userId = u.user.id;
+
+  const orgId = await resolveOrg(admin, userId);
+  if (!orgId) return json({ ok: true, data: { org_name: null, org_logo_url: null, settings: {} } });
+
+  const { data: org, error: orgErr } = await admin.from("organizations").select("name, logo_url").eq("id", orgId).maybeSingle();
+  if (orgErr) { log.error("org_read_failed", { err: orgErr.message, org_id: orgId }); return json({ ok: false, code: "READ_FAILED" }, 500); }
+  const { data: os, error: osErr } = await admin.from("org_settings").select("quote_defaults").eq("org_id", orgId).maybeSingle();
+  if (osErr) { log.error("settings_read_failed", { err: osErr.message, org_id: orgId }); return json({ ok: false, code: "READ_FAILED" }, 500); }
+
+  return json({ ok: true, data: { org_name: org?.name ?? null, org_logo_url: org?.logo_url ?? null, settings: os?.quote_defaults ?? {} } });
+});

--- a/supabase/functions/quote-settings-update/index.ts
+++ b/supabase/functions/quote-settings-update/index.ts
@@ -1,0 +1,72 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createLogger, requestId } from "../_shared/logger.ts";
+import { resolveOrg, numOrNull } from "../_shared/quote_helpers.ts";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { ...cors, "Content-Type": "application/json" } });
+
+const MAX_IMAGE_CHARS = 700_000;
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: cors });
+  if (req.method !== "POST") return json({ ok: false, code: "METHOD_NOT_ALLOWED" }, 405);
+  const log = createLogger("quote-settings-update", { request_id: requestId() });
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const url = Deno.env.get("SUPABASE_URL")!, anon = Deno.env.get("SUPABASE_ANON_KEY")!, svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const userClient = createClient(url, anon, { global: { headers: { Authorization: auth } } });
+  const admin = createClient(url, svc);
+  const { data: u } = await userClient.auth.getUser();
+  if (!u?.user) return json({ ok: false, code: "UNAUTHORIZED" }, 401);
+  const userId = u.user.id;
+
+  const orgId = await resolveOrg(admin, userId);
+  if (!orgId) return json({ ok: false, code: "NO_ORG" }, 403);
+
+  // Org branding is admin-only: caller must be an org owner/admin (active member
+  // of THIS org) OR a platform admin. Inlined (instead of _shared/auth.ts's
+  // isUserAdmin) to avoid crossing the supabase-js version boundary and to scope
+  // the org-admin check to the resolved org rather than the user's primary row.
+  const [platformAdmin, orgMember] = await Promise.all([
+    admin.from("platform_admins").select("user_id").eq("user_id", userId).maybeSingle(),
+    admin.from("org_members").select("role").eq("user_id", userId).eq("org_id", orgId).eq("status", "active").maybeSingle(),
+  ]);
+  const isPlatformAdmin = Boolean(platformAdmin.data);
+  const isOrgAdmin = ["owner", "admin"].includes(orgMember.data?.role ?? "");
+  if (!isOrgAdmin && !isPlatformAdmin) return json({ ok: false, code: "FORBIDDEN" }, 403);
+
+  const body = await req.json().catch(() => ({}));
+  const raw = body?.settings;
+  // Reject arrays / null / non-objects — quote_defaults must be a plain object.
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return json({ ok: false, code: "INVALID_INPUT", message: "settings must be a plain object" }, 400);
+  }
+  const settings: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
+
+  // Cap base64 data-URI images so we don't bloat the row.
+  for (const key of ["logo_url", "signature_url"]) {
+    const v = settings[key];
+    if (typeof v === "string" && v.length > MAX_IMAGE_CHARS) {
+      return json({ ok: false, code: "IMAGE_TOO_LARGE", message: `${key} exceeds ${MAX_IMAGE_CHARS} chars` }, 413);
+    }
+  }
+
+  // Numeric guard for fuel surcharge: empty string / NaN → omit.
+  if ("default_fuel_surcharge_pct" in settings) {
+    const n = numOrNull(settings.default_fuel_surcharge_pct);
+    if (n === null) delete settings.default_fuel_surcharge_pct;
+    else settings.default_fuel_surcharge_pct = n;
+  }
+
+  const { data: saved, error } = await admin.from("org_settings")
+    .upsert({ org_id: orgId, quote_defaults: settings, updated_at: new Date().toISOString() }, { onConflict: "org_id" })
+    .select("quote_defaults").single();
+  if (error) { log.error("settings_upsert_failed", { err: error.message, org_id: orgId }); return json({ ok: false, code: "UPDATE_FAILED" }, 500); }
+
+  return json({ ok: true, data: { settings: saved?.quote_defaults ?? settings } });
+});

--- a/supabase/functions/quote-update/index.ts
+++ b/supabase/functions/quote-update/index.ts
@@ -1,6 +1,13 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { createLogger, requestId } from "../_shared/logger.ts";
-import { resolveOrg, requireQuotingFeature, computeTotals, LineItem } from "../_shared/quote_helpers.ts";
+import { resolveOrg, requireQuotingFeature, computeTotals, LineItem, numOrNull, numOr, emptyToNull } from "../_shared/quote_helpers.ts";
+
+// Numeric and date columns that must be coerced from form "" → null before update.
+const NUMERIC_FIELDS = new Set([
+  "distance_miles", "container_count", "weight_lbs", "volume_cbm", "pallet_count",
+  "cargo_value", "fuel_surcharge_pct", "benchmark_low", "benchmark_high", "revenue_opportunity",
+]);
+const DATE_FIELDS = new Set(["valid_until"]);
 
 const cors = {
   "Access-Control-Allow-Origin": "*",
@@ -27,7 +34,10 @@ const EDITABLE_FIELDS = [
 function pickQuoteFields(body: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const k of EDITABLE_FIELDS) {
-    if (body[k] !== undefined) out[k] = body[k];
+    if (body[k] === undefined) continue;
+    if (NUMERIC_FIELDS.has(k)) out[k] = numOrNull(body[k]);
+    else if (DATE_FIELDS.has(k)) out[k] = emptyToNull(body[k]);
+    else out[k] = body[k];
   }
   return out;
 }
@@ -67,7 +77,7 @@ Deno.serve(async (req) => {
   if (items.length) {
     await admin.from("lit_quote_line_items").insert(items.map((li, i) => ({
       quote_id: quoteId, org_id: orgId, type: li.type ?? null, name: li.name, description: li.description ?? null,
-      unit: li.unit ?? null, quantity: li.quantity ?? 1, unit_cost: li.unit_cost ?? 0, unit_sell: li.unit_sell ?? 0,
+      unit: li.unit ?? null, quantity: numOr(li.quantity, 1), unit_cost: numOr(li.unit_cost, 0), unit_sell: numOr(li.unit_sell, 0),
       is_accessorial: !!li.is_accessorial, taxable: !!li.taxable, sort_order: li.sort_order ?? i,
     })));
   }


### PR DESCRIPTION
Ships the 10 commits that landed on `feat/quoting-phase1` after PR #120 merged.

## What's included
- **Company search** → restricted to the org's **saved companies** (Command Center), returns internal `company_id`; Supabase-native (replaces flaky gateway); 403/5xx error hardening + retry.
- **Save Draft fix** → coerce empty-string numeric/date fields to null (was 500).
- **Send fix** → support the connected **Resend** sender; quotes send from the user's own Gmail/Outlook when connected.
- **Email link fix** → always append the secure "View your quote" button (custom body was dropping it).
- **Auto-mileage** → `quote-distance` (Nominatim geocode + OSRM routing) auto-fills Distance on domestic lanes; manual override; no fabricated values.
- **Location autocomplete** → Photon/OSM type-ahead on origin/destination city fields.
- **Quote Settings page** (`/app/quoting/settings`) → org branding/defaults (logo, company info, signature, payment terms, fuel %, currency, T&C) stored in `org_settings.quote_defaults`; Builder prefills from it; **branded PDF** (logo/signature/company block/terms). Admin-gated.
- **Field persistence** → `quote-create` now saves hazmat/temp_controlled/volume_cbm/pallet_count.
- **Frontend entitlement gating** (locks create/send when `quoting` not in plan; server-enforced).

## Edge functions deployed (already live on shared project)
quote-create v5, quote-update, quote-list, quote-detail, quote-status-update, quote-generate-pdf, quote-send v4, quote-view (public), dashboard/company metrics, quote-company-search v2, quote-distance, quote-settings-get, quote-settings-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)