### PR TITLE
Add Pulse Explorer video SEO enhancements

### DIFF
--- a/marketing/app/company-intelligence/page.tsx
+++ b/marketing/app/company-intelligence/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, Play } from "lucide-react";
 import { PageShell } from "@/components/sections/PageShell";
 import { PulseExplorerHero } from "@/components/sections/pulse-explorer/PulseExplorerHero";
 import { OpportunityScoring } from "@/components/sections/pulse-explorer/OpportunityScoring";
@@ -7,94 +9,403 @@ import { CoachSection } from "@/components/sections/pulse-explorer/CoachSection"
 import { FeatureShowcase } from "@/components/sections/pulse-explorer/FeatureShowcase";
 import { CapabilityBand } from "@/components/sections/pulse-explorer/CapabilityBand";
 import { PulseFinalCta } from "@/components/sections/pulse-explorer/PulseFinalCta";
+import { PulseVideoButton } from "@/components/sections/pulse-explorer/PulseVideoButton";
 import { buildMetadata, siteUrl } from "@/lib/seo";
 
-const PAGE_TITLE = "Pulse Explorer V2 — Map-First Company Intelligence | Logistic Intel";
+const PAGE_TITLE = "Pulse Explorer | Freight Prospecting Software for Brokers, Forwarders, and 3PLs";
 const PAGE_DESCRIPTION =
-  "78K+ U.S. shipper accounts as a living map. Opportunity scoring on every account, natural-language search, Pulse Coach AI, and branded PDF reports — find high-value shippers before your competitors.";
+  "Discover Pulse Explorer by Logistics Intel, a freight prospecting tool that helps brokers, forwarders, and 3PLs find active shippers, analyze trade lanes, enrich contacts, and build targeted lead lists.";
+const DEMO_URL = "https://cal.com/logisticintel/30min";
+const VIDEO_URL = "https://www.youtube.com/watch?v=a9FhnCW89wY";
+const VIDEO_THUMBNAIL_URL = "https://i.ytimg.com/vi/a9FhnCW89wY/maxresdefault.jpg";
+
+const LEARNING_BULLETS = [
+  "Search active shippers by company name, region, city, state, or ZIP code",
+  "Analyze company shipment activity, TEU volume, and trade lanes",
+  "View opportunities on the map, heat map, and list view",
+  "Find and enrich logistics and supply chain contacts",
+  "Save custom prospecting views to your Library",
+  "Use the AI Assistant to generate insights and reports",
+  "Download or email reports to your team",
+];
+
+const INTERNAL_LINKS = [
+  { href: "/features", label: "freight prospecting software features" },
+  { href: "/products", label: "freight revenue intelligence platform" },
+  { href: "/best/best-freight-prospecting-tools", label: "best freight prospecting tools" },
+  { href: "/resources", label: "freight sales playbooks" },
+  { href: "/glossary", label: "freight and logistics glossary" },
+  { href: "/pricing", label: "Logistics Intel pricing" },
+];
+
+const FAQS = [
+  {
+    question: "What is Pulse Explorer?",
+    answer:
+      "Pulse Explorer is Logistics Intel's freight prospecting software for brokers, freight forwarders, 3PLs, and logistics sales teams. It helps teams find active shippers, analyze shipment activity, enrich contacts, map opportunities, and create targeted lead lists.",
+  },
+  {
+    question: "How does Pulse Explorer help with freight prospecting?",
+    answer:
+      "Pulse Explorer combines shipment intelligence, company intelligence, map-based search, contact enrichment, saved views, and AI-generated insights so sales teams can identify high-fit shipper accounts faster.",
+  },
+  {
+    question: "Who is Pulse Explorer built for?",
+    answer:
+      "Pulse Explorer is built for freight brokers, freight forwarders, 3PLs, carriers, and logistics sales teams that need better shipper data, cleaner lead lists, and faster account research.",
+  },
+  {
+    question: "Does Pulse Explorer include shipper leads?",
+    answer:
+      "Pulse Explorer helps users discover active shipper accounts and company-level freight signals. Teams can search by company, region, city, state, ZIP code, trade lane, and shipment activity to build targeted prospect lists.",
+  },
+  {
+    question: "Can I watch a Pulse Explorer demo?",
+    answer:
+      "Yes. You can watch the Pulse Explorer tutorial video on this page or book a live demo with the Logistics Intel team.",
+  },
+  {
+    question: "Can Pulse Explorer generate reports?",
+    answer:
+      "Pulse Explorer can generate branded freight intelligence reports using account data, shipment signals, lane insights, contact information, and AI-assisted summaries.",
+  },
+];
 
 export const metadata: Metadata = buildMetadata({
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
   path: "/company-intelligence",
-  eyebrow: "Pulse Explorer V2",
+  eyebrow: "Pulse Explorer",
 });
 
-/**
- * SoftwareApplication JSON-LD for the Pulse Explorer V2 product surface.
- * Signals to Google + AI search engines that this is a discrete product
- * page (not just marketing copy), unlocks rich-result eligibility for
- * software-listing snippets, and grounds the feature claims in
- * structured data. No fabricated aggregateRating — we don't expose
- * customer reviews on this surface yet, and faking them risks Google's
- * structured-data spam policy.
- */
 const SOFTWARE_APPLICATION_JSONLD = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
-  name: "Pulse Explorer V2",
-  alternateName: "Logistic Intel — Map-First Company Intelligence",
+  name: "Pulse Explorer",
   description: PAGE_DESCRIPTION,
   url: siteUrl("/company-intelligence"),
   applicationCategory: "BusinessApplication",
-  applicationSubCategory: "Sales Intelligence",
   operatingSystem: "Web",
-  image: siteUrl(
-    "/api/og?title=Pulse%20Explorer%20V2%20%E2%80%94%20Map-First%20Company%20Intelligence%20%7C%20Logistic%20Intel&eyebrow=Pulse%20Explorer%20V2",
-  ),
-  featureList: [
-    "Map-first view of 78,000+ U.S. shipper accounts",
-    "Opportunity score on every account (volume, lane fit, recency, mode mix)",
-    "Natural-language search — ask in plain English, watch the map filter",
-    "Pulse Coach AI for account briefs, talk tracks, and signal recaps",
-    "Branded PDF executive reports per account",
-    "Saved-list watchlists with shipment-change alerts",
-    "HS-code, lane, and carrier filters on every map view",
-    "Verified Logistics + Transportation decision-maker contacts",
-  ],
+  brand: {
+    "@type": "Brand",
+    name: "Logistics Intel",
+  },
   offers: {
     "@type": "Offer",
-    name: "Free trial",
-    description: "Start free — no credit card required.",
-    price: "0",
+    url: siteUrl("/pricing"),
     priceCurrency: "USD",
-    url: siteUrl("/signup"),
-    availability: "https://schema.org/InStock",
-    category: "FreeTrial",
   },
-  provider: {
-    "@type": "Organization",
-    name: "Logistic Intel",
-    url: siteUrl("/"),
-  },
-  isAccessibleForFree: true,
 };
 
-/**
- * Pulse Explorer V2 — map-first sales intelligence. Rebuilt from the
- * 2026-06 handoff (Drive: MARKETING SITE). Hero hosts a real Leaflet +
- * OpenStreetMap basemap so the marketing surface matches the live
- * product UI exactly. All sections are composed top-down from
- * components/sections/pulse-explorer/ — keep new state local there, not
- * in this route file.
- */
+const VIDEO_OBJECT_JSONLD = {
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  name: "Pulse Explorer Tutorial",
+  description:
+    "See how Logistics Intel helps freight teams search active shippers, analyze trade lanes, enrich contacts, save views, and generate freight intelligence reports from one workspace.",
+  thumbnailUrl: [VIDEO_THUMBNAIL_URL],
+  embedUrl: "https://www.youtube.com/embed/a9FhnCW89wY",
+  contentUrl: VIDEO_URL,
+  publisher: {
+    "@type": "Organization",
+    name: "Logistics Intel",
+    logo: {
+      "@type": "ImageObject",
+      url: siteUrl("/icon-512.png"),
+    },
+  },
+};
+
+const FAQ_PAGE_JSONLD = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQS.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+};
+
 export default function CompanyIntelligencePage() {
   return (
     <PageShell>
-      {/* SoftwareApplication structured data. JSON-LD only — no visible UI. */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(SOFTWARE_APPLICATION_JSONLD) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(VIDEO_OBJECT_JSONLD) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_PAGE_JSONLD) }}
+      />
       <div className="lit-page">
         <PulseExplorerHero />
+        <VideoTutorialSection />
+        <LearningSection />
         <OpportunityScoring />
         <NLSearchSection />
         <CoachSection />
         <FeatureShowcase />
         <CapabilityBand />
+        <InternalLinksSection />
+        <PulseFaqSection />
         <PulseFinalCta />
       </div>
     </PageShell>
+  );
+}
+
+function VideoTutorialSection() {
+  return (
+    <section className="section" style={{ paddingTop: 46, paddingBottom: 58 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 1120 }}>
+        <div className="section-title" style={{ marginBottom: 28 }}>
+          <div className="eyebrow">Product tutorial</div>
+          <h2 className="display-lg">Watch the Pulse Explorer Tutorial</h2>
+          <p className="lead" style={{ maxWidth: 760 }}>
+            See how Logistics Intel helps freight teams search active shippers,
+            analyze trade lanes, enrich contacts, save views, and generate freight
+            intelligence reports from one workspace.
+          </p>
+        </div>
+
+        <div
+          className="card-glossy"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            gap: 24,
+            alignItems: "center",
+            padding: 24,
+          }}
+        >
+          <PulseVideoButton
+            style={{
+              position: "relative",
+              minHeight: 280,
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 14,
+              overflow: "hidden",
+              cursor: "pointer",
+              background: `linear-gradient(180deg, rgba(2,6,23,0.1), rgba(2,6,23,0.72)), url(${VIDEO_THUMBNAIL_URL}) center / cover`,
+              boxShadow: "0 28px 70px rgba(15,23,42,0.16)",
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <span
+                style={{
+                  width: 74,
+                  height: 74,
+                  borderRadius: 999,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: "linear-gradient(135deg,#2563eb,#06b6d4)",
+                  color: "#fff",
+                  boxShadow: "0 24px 58px rgba(37,99,235,0.34)",
+                }}
+              >
+                <Play size={28} fill="currentColor" />
+              </span>
+            </span>
+            <span
+              style={{
+                position: "absolute",
+                left: 18,
+                bottom: 18,
+                padding: "9px 12px",
+                borderRadius: 999,
+                background: "rgba(2,6,23,0.78)",
+                color: "#fff",
+                fontFamily: "var(--font-display)",
+                fontSize: 13,
+                fontWeight: 700,
+                border: "1px solid rgba(255,255,255,0.18)",
+              }}
+            >
+              Watch 5-Minute Demo
+            </span>
+          </PulseVideoButton>
+
+          <div style={{ padding: "4px 6px" }}>
+            <div className="eyebrow">Freight prospecting demo</div>
+            <h3
+              style={{
+                marginTop: 10,
+                marginBottom: 12,
+                fontFamily: "var(--font-display)",
+                fontSize: "clamp(28px, 4vw, 42px)",
+                lineHeight: 1.05,
+                color: "var(--ink-900, #0b1220)",
+              }}
+            >
+              See the shipper search workflow before you book time.
+            </h3>
+            <p className="lead" style={{ marginBottom: 22 }}>
+              Open the YouTube tutorial when you want a quick walkthrough, or book
+              time with the Logistics Intel team for a live Pulse Explorer demo.
+            </p>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <a
+                href={DEMO_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="btn btn-primary btn-lg"
+                style={{ textDecoration: "none" }}
+              >
+                Book a Pulse Explorer Demo
+                <ArrowRight size={16} />
+              </a>
+              <Link
+                href="/resources"
+                className="btn btn-secondary btn-lg"
+                style={{ textDecoration: "none" }}
+              >
+                Freight sales playbooks
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LearningSection() {
+  return (
+    <section className="section" style={{ paddingTop: 42, paddingBottom: 62 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 1120 }}>
+        <div className="section-title" style={{ marginBottom: 28 }}>
+          <div className="eyebrow">Demo agenda</div>
+          <h2 className="display-lg">What You'll Learn in the Pulse Explorer Demo</h2>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
+            gap: 14,
+          }}
+        >
+          {LEARNING_BULLETS.map((item) => (
+            <div
+              key={item}
+              className="card-glossy"
+              style={{ display: "flex", gap: 10, padding: 18, alignItems: "flex-start" }}
+            >
+              <CheckCircle2 size={18} color="#10b981" style={{ marginTop: 2, flex: "0 0 auto" }} />
+              <p style={{ margin: 0, color: "rgba(15,23,42,0.74)", lineHeight: 1.55 }}>
+                {item}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function InternalLinksSection() {
+  return (
+    <section className="section" style={{ paddingTop: 44, paddingBottom: 58 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 980 }}>
+        <div className="card-glossy" style={{ padding: 28 }}>
+          <div className="eyebrow">Explore more Logistics Intel resources</div>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 10,
+              marginTop: 16,
+            }}
+          >
+            {INTERNAL_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                style={{
+                  border: "1px solid rgba(37,99,235,0.16)",
+                  borderRadius: 999,
+                  padding: "9px 12px",
+                  color: "var(--brand-blue-700, #2563eb)",
+                  background: "rgba(37,99,235,0.06)",
+                  textDecoration: "none",
+                  fontFamily: "var(--font-display)",
+                  fontSize: 13,
+                  fontWeight: 700,
+                }}
+              >
+                {link.label}
+              </Link>
+            ))}
+            <a
+              href={DEMO_URL}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                border: "1px solid rgba(6,182,212,0.26)",
+                borderRadius: 999,
+                padding: "9px 12px",
+                color: "#0e7490",
+                background: "rgba(6,182,212,0.08)",
+                textDecoration: "none",
+                fontFamily: "var(--font-display)",
+                fontSize: 13,
+                fontWeight: 700,
+              }}
+            >
+              book a Pulse Explorer demo
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PulseFaqSection() {
+  return (
+    <section className="section" style={{ paddingTop: 46, paddingBottom: 70 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 980 }}>
+        <div className="section-title" style={{ marginBottom: 24 }}>
+          <div className="eyebrow">Pulse Explorer FAQ</div>
+          <h2 className="display-lg">Freight prospecting questions, answered.</h2>
+        </div>
+        <div style={{ display: "grid", gap: 12 }}>
+          {FAQS.map((faq) => (
+            <details key={faq.question} className="card-glossy" style={{ padding: 20 }}>
+              <summary
+                style={{
+                  cursor: "pointer",
+                  fontFamily: "var(--font-display)",
+                  fontSize: 18,
+                  fontWeight: 700,
+                  color: "var(--ink-900, #0b1220)",
+                }}
+              >
+                {faq.question}
+              </summary>
+              <p style={{ margin: "12px 0 0", color: "rgba(15,23,42,0.68)", lineHeight: 1.65 }}>
+                {faq.answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/marketing/components/sections/pulse-explorer/PulseExplorerHero.tsx
+++ b/marketing/components/sections/pulse-explorer/PulseExplorerHero.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowRight, Calendar, Mail, Phone } from "lucide-react";
+import { ArrowRight, Calendar, Mail, Phone, Play } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { APP_SIGNUP_URL } from "@/lib/app-urls";
 import { PulseExplorerMock } from "./PulseExplorerMock";
+import { PulseVideoButton } from "./PulseVideoButton";
 import type { MapMode } from "./PulseMapCanvas";
+
+const DEMO_URL = "https://cal.com/logisticintel/30min";
 
 const KPIS: Array<[string, string]> = [
   ["78K+", "Shipper accounts mapped"],
@@ -54,21 +57,20 @@ export function PulseExplorerHero() {
             New · Pulse Explorer V2 — map-first sales intelligence
           </div>
           <h1 className="display-xl" style={{ marginTop: 22 }}>
-            Find high-value shippers before your competitors —{" "}
-            <span className="grad-text-cyan">on one live map.</span>
+            Pulse Explorer: Freight Prospecting Software Built for{" "}
+            <span className="grad-text-cyan">Logistics Sales Teams</span>
           </h1>
           <p
             className="lead"
             style={{
               marginTop: 20,
-              maxWidth: 660,
+              maxWidth: 700,
               marginLeft: "auto",
               marginRight: "auto",
             }}
           >
-            Pulse Explorer plots 78K+ U.S. shipper accounts as a living map,
-            scores every opportunity, and answers plain-English questions —
-            so your team works the right accounts first.
+            Find active shippers, analyze trade lanes, enrich decision-makers,
+            and build targeted lead lists from one interactive freight intelligence workspace.
           </p>
           <div
             style={{
@@ -79,9 +81,9 @@ export function PulseExplorerHero() {
               flexWrap: "wrap",
             }}
           >
-            <Button variant="primary" size="lg" href="/book-a-demo">
+            <Button variant="primary" size="lg" href={DEMO_URL}>
               <Calendar size={16} />
-              Book a Demo
+              Book a Pulse Explorer Demo
             </Button>
             <Button variant="secondary" size="lg" href={APP_SIGNUP_URL}>
               Start Free
@@ -111,8 +113,52 @@ export function PulseExplorerHero() {
               filter: "blur(4px)",
             }}
           />
-          <div style={{ position: "relative" }}>
+          <div
+            aria-label="Pulse Explorer freight prospecting software map interface by Logistics Intel"
+            style={{ position: "relative" }}
+          >
             <PulseExplorerMock mode={mode} onMode={setMode} />
+            <PulseVideoButton
+              style={{
+                position: "absolute",
+                left: "50%",
+                top: "50%",
+                zIndex: 1300,
+                transform: "translate(-50%, -50%)",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 10,
+                minHeight: 48,
+                padding: "0 18px",
+                borderRadius: 999,
+                border: "1px solid rgba(255,255,255,0.28)",
+                background: "rgba(2,6,23,0.82)",
+                color: "#fff",
+                boxShadow: "0 20px 48px rgba(2,6,23,0.32)",
+                fontFamily: "var(--font-display)",
+                fontWeight: 700,
+                fontSize: 14,
+                cursor: "pointer",
+                backdropFilter: "blur(10px)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: "linear-gradient(135deg,#2563eb,#06b6d4)",
+                }}
+              >
+                <Play size={14} fill="currentColor" />
+              </span>
+              Watch the Demo
+            </PulseVideoButton>
           </div>
           {/* QuickCard — kept INSIDE the frame bounds (right:18, bottom:24)
               per handoff Jun-17 fix; never use negative offsets while the

--- a/marketing/components/sections/pulse-explorer/PulseVideoButton.tsx
+++ b/marketing/components/sections/pulse-explorer/PulseVideoButton.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useId, useState, type CSSProperties, type ReactNode } from "react";
+import { Play, X } from "lucide-react";
+
+const PULSE_EXPLORER_EMBED_URL = "https://www.youtube.com/embed/a9FhnCW89wY";
+
+type PulseVideoButtonProps = {
+  children?: ReactNode;
+  className?: string;
+  label?: string;
+  style?: CSSProperties;
+};
+
+export function PulseVideoButton({
+  children,
+  className,
+  label = "Watch the Demo",
+  style,
+}: PulseVideoButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Watch Pulse Explorer tutorial video"
+        className={className}
+        onClick={() => setIsOpen(true)}
+        style={style}
+      >
+        {children ?? (
+          <>
+            <Play size={16} fill="currentColor" />
+            {label}
+          </>
+        )}
+      </button>
+
+      {isOpen ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          onClick={() => setIsOpen(false)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 9999,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 20,
+            background: "rgba(2, 6, 23, 0.82)",
+            backdropFilter: "blur(10px)",
+          }}
+        >
+          <div
+            onClick={(event) => event.stopPropagation()}
+            style={{
+              width: "min(960px, 100%)",
+              borderRadius: 18,
+              overflow: "hidden",
+              background: "#020617",
+              border: "1px solid rgba(255,255,255,0.16)",
+              boxShadow: "0 36px 100px rgba(0,0,0,0.38)",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                justifyContent: "space-between",
+                padding: "14px 16px",
+                color: "#fff",
+              }}
+            >
+              <h2
+                id={titleId}
+                style={{
+                  margin: 0,
+                  fontFamily: "var(--font-display)",
+                  fontSize: 16,
+                  fontWeight: 700,
+                }}
+              >
+                Pulse Explorer Tutorial
+              </h2>
+              <button
+                type="button"
+                aria-label="Close video"
+                onClick={() => setIsOpen(false)}
+                style={{
+                  width: 34,
+                  height: 34,
+                  border: "1px solid rgba(255,255,255,0.16)",
+                  borderRadius: 999,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  background: "rgba(255,255,255,0.08)",
+                  cursor: "pointer",
+                }}
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div style={{ aspectRatio: "16 / 9", background: "#000" }}>
+              <iframe
+                title="Pulse Explorer Tutorial"
+                src={`${PULSE_EXPLORER_EMBED_URL}?rel=0&modestbranding=1`}
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                style={{ width: "100%", height: "100%", border: 0, display: "block" }}
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a click-to-load YouTube demo modal for Pulse Explorer, including a hero play overlay and below-hero video card
- update the Pulse Explorer page title, description, H1, hero subtext, demo learning section, internal SEO links, and FAQ content
- add SoftwareApplication, VideoObject, and FAQPage JSON-LD for the public `/company-intelligence` page

## Scope guard
- marketing page only: `/company-intelligence` and Pulse Explorer section component
- no app functionality, auth, APIs, dashboard, database, Supabase functions, or Intelligence Explorer changes

## Note
The requested `/lead-magnets/top-100-shippers` CTA was not added because that public route does not exist in the repo, and the instructions said not to invent a broken lead-magnet URL.