### PR TITLE
Add Pulse Explorer playbook CTA and Cal embed

### DIFF
--- a/marketing/app/company-intelligence/page.tsx
+++ b/marketing/app/company-intelligence/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, CheckCircle2, Play } from "lucide-react";
+import { ArrowRight, Calendar, CheckCircle2, Download, Play } from "lucide-react";
 import { PageShell } from "@/components/sections/PageShell";
 import { PulseExplorerHero } from "@/components/sections/pulse-explorer/PulseExplorerHero";
 import { OpportunityScoring } from "@/components/sections/pulse-explorer/OpportunityScoring";
@@ -9,13 +9,16 @@ import { CoachSection } from "@/components/sections/pulse-explorer/CoachSection"
 import { FeatureShowcase } from "@/components/sections/pulse-explorer/FeatureShowcase";
 import { CapabilityBand } from "@/components/sections/pulse-explorer/CapabilityBand";
 import { PulseFinalCta } from "@/components/sections/pulse-explorer/PulseFinalCta";
+import { CalInlineEmbed } from "@/components/sections/pulse-explorer/CalInlineEmbed";
 import { PulseVideoButton } from "@/components/sections/pulse-explorer/PulseVideoButton";
 import { buildMetadata, siteUrl } from "@/lib/seo";
 
 const PAGE_TITLE = "Pulse Explorer | Freight Prospecting Software for Brokers, Forwarders, and 3PLs";
 const PAGE_DESCRIPTION =
   "Discover Pulse Explorer by Logistics Intel, a freight prospecting tool that helps brokers, forwarders, and 3PLs find active shippers, analyze trade lanes, enrich contacts, and build targeted lead lists.";
-const DEMO_URL = "https://cal.com/logisticintel/30min";
+const DEMO_URL = "#book-demo";
+const DIRECT_DEMO_URL = "https://cal.com/logisticintel/15min";
+const PLAYBOOK_URL = "/freight-leads";
 const VIDEO_URL = "https://www.youtube.com/watch?v=a9FhnCW89wY";
 const VIDEO_THUMBNAIL_URL = "https://i.ytimg.com/vi/a9FhnCW89wY/maxresdefault.jpg";
 
@@ -62,7 +65,7 @@ const FAQS = [
   {
     question: "Can I watch a Pulse Explorer demo?",
     answer:
-      "Yes. You can watch the Pulse Explorer tutorial video on this page or book a live demo with the Logistics Intel team.",
+      "Yes. You can watch the Pulse Explorer tutorial video on this page or schedule a 15-minute demo with the Logistics Intel team.",
   },
   {
     question: "Can Pulse Explorer generate reports?",
@@ -147,6 +150,8 @@ export default function CompanyIntelligencePage() {
       <div className="lit-page">
         <PulseExplorerHero />
         <VideoTutorialSection />
+        <LeadMagnetCtaSection />
+        <DemoSchedulerSection />
         <LearningSection />
         <OpportunityScoring />
         <NLSearchSection />
@@ -257,14 +262,12 @@ function VideoTutorialSection() {
               See the shipper search workflow before you book time.
             </h3>
             <p className="lead" style={{ marginBottom: 22 }}>
-              Open the YouTube tutorial when you want a quick walkthrough, or book
-              time with the Logistics Intel team for a live Pulse Explorer demo.
+              Open the YouTube tutorial when you want a quick walkthrough, or
+              use the calendar below to schedule a live Pulse Explorer demo.
             </p>
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
               <a
                 href={DEMO_URL}
-                target="_blank"
-                rel="noreferrer"
                 className="btn btn-primary btn-lg"
                 style={{ textDecoration: "none" }}
               >
@@ -272,15 +275,120 @@ function VideoTutorialSection() {
                 <ArrowRight size={16} />
               </a>
               <Link
-                href="/resources"
+                href={PLAYBOOK_URL}
                 className="btn btn-secondary btn-lg"
                 style={{ textDecoration: "none" }}
               >
-                Freight sales playbooks
+                Download the Free Freight Prospecting Playbook
               </Link>
             </div>
           </div>
         </div>
+      </div>
+    </section>
+  );
+}
+
+function LeadMagnetCtaSection() {
+  return (
+    <section className="section" style={{ paddingTop: 18, paddingBottom: 52 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 1120 }}>
+        <div
+          style={{
+            borderRadius: 18,
+            padding: "32px clamp(22px, 4vw, 42px)",
+            background: "linear-gradient(135deg, #020617 0%, #07172f 58%, #0e7490 130%)",
+            color: "#fff",
+            boxShadow: "0 34px 90px rgba(2,6,23,0.18)",
+            display: "grid",
+            gridTemplateColumns: "minmax(0, 1fr) auto",
+            gap: 22,
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                fontWeight: 800,
+                textTransform: "uppercase",
+                letterSpacing: "0.14em",
+                color: "#67e8f9",
+                marginBottom: 10,
+              }}
+            >
+              Free freight prospecting resource
+            </div>
+            <h2
+              style={{
+                margin: 0,
+                fontFamily: "var(--font-display)",
+                fontSize: "clamp(28px, 4vw, 44px)",
+                lineHeight: 1.05,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              Download the Free Freight Prospecting Playbook
+            </h2>
+            <p style={{ maxWidth: 700, margin: "12px 0 0", color: "rgba(255,255,255,0.72)", lineHeight: 1.65 }}>
+              See how modern freight teams find active shippers, prioritize the
+              right accounts, and turn shipment signals into targeted outreach.
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <Link
+              href={PLAYBOOK_URL}
+              className="btn btn-primary btn-lg"
+              style={{ textDecoration: "none", background: "#fff", color: "#0f172a" }}
+            >
+              <Download size={16} />
+              Download Playbook
+            </Link>
+            <a
+              href={DEMO_URL}
+              className="btn btn-secondary btn-lg"
+              style={{ textDecoration: "none", color: "#fff", borderColor: "rgba(255,255,255,0.24)", background: "rgba(255,255,255,0.08)" }}
+            >
+              <Calendar size={16} />
+              Book 15 Minutes
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DemoSchedulerSection() {
+  return (
+    <section id="book-demo" className="section" style={{ paddingTop: 44, paddingBottom: 70 }}>
+      <div className="mx-auto px-8" style={{ maxWidth: 1120 }}>
+        <div className="section-title" style={{ marginBottom: 28 }}>
+          <div className="eyebrow">Book a live demo</div>
+          <h2 className="display-lg">Pick a 15-minute Pulse Explorer slot.</h2>
+          <p className="lead" style={{ maxWidth: 720 }}>
+            Choose a time that works for you. The calendar below uses the configured
+            Logistics Intel 15-minute Cal.com event.
+          </p>
+        </div>
+        <div
+          className="card-glossy"
+          style={{
+            padding: 12,
+            minHeight: 760,
+            overflow: "hidden",
+            borderRadius: 18,
+          }}
+        >
+          <CalInlineEmbed />
+        </div>
+        <p style={{ margin: "12px 0 0", textAlign: "center", color: "rgba(15,23,42,0.58)", fontSize: 13 }}>
+          Calendar not loading?{" "}
+          <a href={DIRECT_DEMO_URL} target="_blank" rel="noreferrer" style={{ color: "var(--brand-blue-700, #2563eb)", fontWeight: 700 }}>
+            Open the 15-minute scheduler directly.
+          </a>
+        </p>
       </div>
     </section>
   );
@@ -354,8 +462,6 @@ function InternalLinksSection() {
             ))}
             <a
               href={DEMO_URL}
-              target="_blank"
-              rel="noreferrer"
               style={{
                 border: "1px solid rgba(6,182,212,0.26)",
                 borderRadius: 999,

--- a/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
+++ b/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
@@ -11,6 +11,8 @@ declare global {
 const CAL_NAMESPACE = "15min";
 const CAL_LINK = "logisticintel/15min";
 
+type QueuedCalApi = ((...args: any[]) => void) & { q?: any[] };
+
 export function CalInlineEmbed() {
   useEffect(() => {
     (function (C: Window, A: string, L: string) {
@@ -30,7 +32,7 @@ export function CalInlineEmbed() {
             cal.loaded = true;
           }
           if (ar[0] === L) {
-            const api = function () {
+            const api: QueuedCalApi = function () {
               p(api, arguments);
             };
             const namespace = ar[1];

--- a/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
+++ b/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
@@ -2,20 +2,17 @@
 
 import { useEffect } from "react";
 
-declare global {
-  interface Window {
-    Cal?: any;
-  }
-}
-
 const CAL_NAMESPACE = "15min";
 const CAL_LINK = "logisticintel/15min";
 
 type QueuedCalApi = ((...args: any[]) => void) & { q?: any[] };
+type CalWindow = Window & { Cal?: any };
 
 export function CalInlineEmbed() {
   useEffect(() => {
-    (function (C: Window, A: string, L: string) {
+    const calWindow = window as CalWindow;
+
+    (function (C: CalWindow, A: string, L: string) {
       const p = function (a: any, ar: IArguments | any[]) {
         a.q.push(ar);
       };
@@ -48,17 +45,17 @@ export function CalInlineEmbed() {
           }
           p(cal, ar);
         };
-    })(window, "https://app.cal.com/embed/embed.js", "init");
+    })(calWindow, "https://app.cal.com/embed/embed.js", "init");
 
-    window.Cal?.("init", CAL_NAMESPACE, { origin: "https://app.cal.com" });
-    window.Cal!.config = window.Cal!.config || {};
-    window.Cal!.config.forwardQueryParams = true;
-    window.Cal?.ns?.[CAL_NAMESPACE]?.("inline", {
+    calWindow.Cal?.("init", CAL_NAMESPACE, { origin: "https://app.cal.com" });
+    calWindow.Cal!.config = calWindow.Cal!.config || {};
+    calWindow.Cal!.config.forwardQueryParams = true;
+    calWindow.Cal?.ns?.[CAL_NAMESPACE]?.("inline", {
       elementOrSelector: "#my-cal-inline-15min",
       config: { layout: "month_view", useSlotsViewOnSmallScreen: "true" },
       calLink: CAL_LINK,
     });
-    window.Cal?.ns?.[CAL_NAMESPACE]?.("ui", {
+    calWindow.Cal?.ns?.[CAL_NAMESPACE]?.("ui", {
       hideEventTypeDetails: false,
       layout: "month_view",
     });

--- a/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
+++ b/marketing/components/sections/pulse-explorer/CalInlineEmbed.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    Cal?: any;
+  }
+}
+
+const CAL_NAMESPACE = "15min";
+const CAL_LINK = "logisticintel/15min";
+
+export function CalInlineEmbed() {
+  useEffect(() => {
+    (function (C: Window, A: string, L: string) {
+      const p = function (a: any, ar: IArguments | any[]) {
+        a.q.push(ar);
+      };
+      const d = C.document;
+      C.Cal =
+        C.Cal ||
+        function () {
+          const cal = C.Cal;
+          const ar = arguments;
+          if (!cal.loaded) {
+            cal.ns = {};
+            cal.q = cal.q || [];
+            d.head.appendChild(d.createElement("script")).src = A;
+            cal.loaded = true;
+          }
+          if (ar[0] === L) {
+            const api = function () {
+              p(api, arguments);
+            };
+            const namespace = ar[1];
+            api.q = api.q || [];
+            if (typeof namespace === "string") {
+              cal.ns[namespace] = cal.ns[namespace] || api;
+              p(cal.ns[namespace], ar);
+              p(cal, ["initNamespace", namespace]);
+            } else {
+              p(cal, ar);
+            }
+            return;
+          }
+          p(cal, ar);
+        };
+    })(window, "https://app.cal.com/embed/embed.js", "init");
+
+    window.Cal?.("init", CAL_NAMESPACE, { origin: "https://app.cal.com" });
+    window.Cal!.config = window.Cal!.config || {};
+    window.Cal!.config.forwardQueryParams = true;
+    window.Cal?.ns?.[CAL_NAMESPACE]?.("inline", {
+      elementOrSelector: "#my-cal-inline-15min",
+      config: { layout: "month_view", useSlotsViewOnSmallScreen: "true" },
+      calLink: CAL_LINK,
+    });
+    window.Cal?.ns?.[CAL_NAMESPACE]?.("ui", {
+      hideEventTypeDetails: false,
+      layout: "month_view",
+    });
+  }, []);
+
+  return (
+    <div
+      id="my-cal-inline-15min"
+      aria-label="Schedule a 15-minute Pulse Explorer demo"
+      style={{ width: "100%", minHeight: 720, height: "100%", overflow: "auto" }}
+    />
+  );
+}

--- a/marketing/components/sections/pulse-explorer/PulseExplorerHero.tsx
+++ b/marketing/components/sections/pulse-explorer/PulseExplorerHero.tsx
@@ -8,7 +8,7 @@ import { PulseExplorerMock } from "./PulseExplorerMock";
 import { PulseVideoButton } from "./PulseVideoButton";
 import type { MapMode } from "./PulseMapCanvas";
 
-const DEMO_URL = "https://cal.com/logisticintel/30min";
+const DEMO_URL = "#book-demo";
 
 const KPIS: Array<[string, string]> = [
   ["78K+", "Shipper accounts mapped"],


### PR DESCRIPTION
## Summary
- Adds a configured inline Cal.com scheduler for the `logisticintel/15min` event on `/company-intelligence`
- Points Pulse Explorer demo CTAs to the inline scheduler instead of the unconfigured 30-minute Cal page
- Adds the requested free freight prospecting playbook CTA using the existing `/freight-leads` route to avoid a broken lead-magnet link

## Notes
- Marketing-only change under `marketing/`
- Does not touch auth, APIs, dashboard, database, Intelligence Explorer, or Supabase functions

## Testing
- Not run locally: workspace copy in this Codex session does not include the checked-out marketing repo files. Vercel preview checks should validate build output.