### PR TITLE
Fix campaign scheduling, KPI visibility, and Gmail HTML test sends

### DIFF
--- a/frontend/src/features/outbound/api/campaignActions.ts
+++ b/frontend/src/features/outbound/api/campaignActions.ts
@@ -104,6 +104,10 @@ export interface CampaignStepRow {
   delay_minutes: number;
   subject_b: string | null;
   include_signature: boolean;
+  // J.2: schedule hints must hydrate too; otherwise a saved "send at
+  // 9:00 AM" step appears unset after navigating away and back.
+  time_of_day_local: string | null;
+  weekdays_only: boolean | null;
 }
 
 export async function getCampaignWithDetails(
@@ -123,10 +127,9 @@ export async function getCampaignWithDetails(
     supabase
       .from("lit_campaign_steps")
       .select(
-        // P0-5: include delay_minutes / subject_b / include_signature so
-        // dbStepToBuilder can rehydrate the A/B variant, the signature
-        // toggle, and minute-precision delays on edit-load.
-        "id, step_order, channel, step_type, subject, body, delay_days, delay_hours, delay_minutes, subject_b, include_signature",
+        // Include the full scheduling surface so dbStepToBuilder can
+        // faithfully rehydrate the builder after navigation/reload.
+        "id, step_order, channel, step_type, subject, body, delay_days, delay_hours, delay_minutes, subject_b, include_signature, time_of_day_local, weekdays_only",
       )
       .eq("campaign_id", campaignId)
       .order("step_order", { ascending: true }),
@@ -281,6 +284,8 @@ export interface SaveCampaignDraftStep {
   delay_hours?: number;
   delay_minutes?: number;
   include_signature?: boolean;
+  time_of_day_local?: string | null;
+  weekdays_only?: boolean;
   metadata?: Record<string, unknown>;
 }
 

--- a/frontend/src/features/outbound/components/CampaignKpiHero.tsx
+++ b/frontend/src/features/outbound/components/CampaignKpiHero.tsx
@@ -1,16 +1,11 @@
 /**
- * CampaignKpiHero — state-dependent hero for the campaign builder.
- * Replaces the old single AUDIENCE SIZE strip.
+ * CampaignKpiHero — top KPI strip for the campaign builder.
  *
- * Draft state (DR Move 4): a single truthful "configuration summary"
- * card showing audience size, schedule, and sequence shape. No
- * industry-average estimate tiles — those signal "metrics demo" not
- * "real outbound campaign you're configuring." A single thin disclosure
- * line explains where rates will appear.
- *
- * Active/paused/complete: shows audience + sent + 4 real rates
- * (open/click/reply/bounce) from the funnel data. Paused state adds
- * a grey "Paused" badge.
+ * The seven-card layout is intentionally stable across draft, active,
+ * paused, and archived campaigns. Draft campaigns still have no real
+ * engagement yet, but keeping the same KPI surface visible prevents the
+ * page from reshaping after launch and makes it obvious where sent/open/
+ * reply metrics will appear once the dispatcher starts writing events.
  */
 import { useState } from "react";
 import type { CampaignFunnel, CampaignStatus } from "../types";
@@ -27,9 +22,6 @@ interface Props {
   sparkData: number[];
   scheduledLabel?: string;
   campaignId?: string | null;
-  /** DR Move 4: sequence shape for the draft summary card (e.g.
-   *  "3 emails over 14 days"). Optional; falls back to a generic
-   *  "Sequence configured" line if not provided. */
   sequenceSummary?: string;
 }
 
@@ -101,7 +93,6 @@ export function CampaignKpiHero({
   campaignId,
   sequenceSummary,
 }: Props) {
-  const isDraft = status === "draft";
   const audienceDisplay = audienceCount > 0 ? formatCount(audienceCount) : "—";
   const [drill, setDrill] = useState<EngagementEventType | null>(null);
 
@@ -119,6 +110,12 @@ export function CampaignKpiHero({
   const replyClick    = canDrill && (funnel?.replied  ?? 0) > 0 ? () => setDrill("replied")  : undefined;
   const bounceClick   = canDrill && (funnel?.bounced  ?? 0) > 0 ? () => setDrill("bounced")  : undefined;
   const meetingsClick = canDrill && (funnel?.meetings ?? 0) > 0 ? () => setDrill("meetings") : undefined;
+
+  const sentHint = hasMeaningfulSpark(sparkData)
+    ? "sends / day, last 14d"
+    : scheduledLabel
+      ? `first send ${scheduledLabel}`
+      : sequenceSummary || "waiting for first send";
 
   return (
     <div className="relative">
@@ -139,123 +136,62 @@ export function CampaignKpiHero({
         </div>
       )}
 
-      {isDraft ? (
-        /* DR Move 4: collapse 6 fake-metric tiles to ONE truthful
-           summary card. Draft campaigns have no real KPIs yet — six
-           tiles of industry-average estimates signalled "metrics demo"
-           and ate ~60% of the page. The card mirrors Tile's visual
-           language (rounded-2xl border bg-white shadow-sm) for
-           continuity, but uses a slate / neutral tone end-to-end so
-           it never competes visually with the live-data hero. */
-        <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
-          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-6">
-            <div className="flex flex-col gap-1">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-                Audience
-              </span>
-              <span className="text-4xl font-bold tabular-nums text-slate-900">
-                {audienceDisplay}
-              </span>
-              <span className="text-[11px] text-slate-500">
-                {audienceCount > 0
-                  ? `${audienceCount === 1 ? "recipient" : "recipients"} selected`
-                  : "Pick recipients to continue"}
-              </span>
-            </div>
-
-            <div className="hidden h-12 w-px shrink-0 bg-slate-200 md:block" aria-hidden="true" />
-
-            <div className="flex flex-col gap-1">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-                Schedule
-              </span>
-              <span className="text-lg font-semibold text-slate-900">
-                {scheduledLabel ?? "Not scheduled"}
-              </span>
-              <span className="text-[11px] text-slate-500">
-                {scheduledLabel ? "First send" : "Pick a time to launch"}
-              </span>
-            </div>
-
-            <div className="hidden h-12 w-px shrink-0 bg-slate-200 md:block" aria-hidden="true" />
-
-            <div className="flex flex-col gap-1">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-                Sequence
-              </span>
-              <span className="text-lg font-semibold text-slate-900">
-                {sequenceSummary ?? "Sequence configured"}
-              </span>
-              <span className="text-[11px] text-slate-500">
-                Steps in this campaign
-              </span>
-            </div>
-          </div>
-
-          <div className="mt-4 border-t border-slate-100 pt-3">
-            <p className="text-[11px] text-slate-500">
-              Open / click / reply rates appear after first send.
-            </p>
-          </div>
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-7">
-          <Tile
-            label="Audience"
-            value={audienceDisplay}
-            hint={audienceCount > 0 ? "selected" : "pick recipients"}
-          />
-          <Tile
-            label="Sent"
-            value={formatCount(funnel?.sent ?? null)}
-            hint={hasMeaningfulSpark(sparkData) ? "sends / day, last 14d" : undefined}
-            spark={sparkData}
-            tone="neutral"
-            onClick={sentClick}
-          />
-          <Tile
-            label="Open Rate"
-            value={formatRate(funnel?.openRate ?? null)}
-            hint={funnel ? `${formatCount(funnel.opened)} opened` : undefined}
-            tone="blue"
-            onClick={openClick}
-          />
-          <Tile
-            label="Click Rate"
-            value={formatRate(funnel?.clickRate ?? null)}
-            hint={funnel ? `${formatCount(funnel.clicked)} clicked` : undefined}
-            tone="indigo"
-            onClick={clickedClick}
-          />
-          <Tile
-            label="Reply Rate"
-            value={formatRate(funnel?.replyRate ?? null)}
-            hint={funnel ? `${formatCount(funnel.replied)} replied` : undefined}
-            tone="emerald"
-            onClick={replyClick}
-          />
-          <Tile
-            label="Bounce Rate"
-            value={formatRate(funnel?.bounceRate ?? null)}
-            hint={funnel ? `${formatCount(funnel.bounced)} bounced` : undefined}
-            tone={bounceTone}
-            onClick={bounceClick}
-          />
-          <Tile
-            label="Meetings"
-            value={formatCount(funnel?.meetings ?? 0)}
-            hint={
-              funnel
-                ? (funnel.meetings ?? 0) > 0
-                  ? "Cal.com booked"
-                  : "Cal.com integration"
-                : undefined
-            }
-            tone="emerald"
-            onClick={meetingsClick}
-          />
-        </div>
-      )}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-7">
+        <Tile
+          label="Audience"
+          value={audienceDisplay}
+          hint={audienceCount > 0 ? "selected" : "pick recipients"}
+        />
+        <Tile
+          label="Sent"
+          value={formatCount(funnel?.sent ?? 0)}
+          hint={sentHint}
+          spark={sparkData}
+          tone="neutral"
+          onClick={sentClick}
+        />
+        <Tile
+          label="Open Rate"
+          value={formatRate(funnel?.openRate ?? null)}
+          hint={funnel ? `${formatCount(funnel.opened)} opened` : "after first send"}
+          tone="blue"
+          onClick={openClick}
+        />
+        <Tile
+          label="Click Rate"
+          value={formatRate(funnel?.clickRate ?? null)}
+          hint={funnel ? `${formatCount(funnel.clicked)} clicked` : "after first send"}
+          tone="indigo"
+          onClick={clickedClick}
+        />
+        <Tile
+          label="Reply Rate"
+          value={formatRate(funnel?.replyRate ?? null)}
+          hint={funnel ? `${formatCount(funnel.replied)} replied` : "after first send"}
+          tone="emerald"
+          onClick={replyClick}
+        />
+        <Tile
+          label="Bounce Rate"
+          value={formatRate(funnel?.bounceRate ?? null)}
+          hint={funnel ? `${formatCount(funnel.bounced)} bounced` : "after first send"}
+          tone={bounceTone}
+          onClick={bounceClick}
+        />
+        <Tile
+          label="Meetings"
+          value={formatCount(funnel?.meetings ?? 0)}
+          hint={
+            funnel
+              ? (funnel.meetings ?? 0) > 0
+                ? "Cal.com booked"
+                : "Cal.com integration"
+              : "Cal.com integration"
+          }
+          tone="emerald"
+          onClick={meetingsClick}
+        />
+      </div>
 
       {/* CR P1-4: conditional mount. The drill-in subscribes to a
           useEngagementRecipients query on mount even though it gates

--- a/supabase/functions/send-test-email/index.ts
+++ b/supabase/functions/send-test-email/index.ts
@@ -45,6 +45,27 @@ function toBase64Url(str: string): string {
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
+function looksLikeHtml(body: string): boolean {
+  return /^<[a-z!]/i.test(body.trim()) || /<table|<div|<p[\s>]|<!doctype/i.test(body);
+}
+
+/**
+ * Gmail raw messages need a transfer encoding for rich HTML bodies.
+ * Without this, non-ASCII characters and HTML entities in branded emails
+ * can be interpreted as literal plain text by Gmail's MIME parser.
+ */
+function encodeBodyMimeBase64(body: string): string {
+  const bytes = new TextEncoder().encode(body);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  const b64 = btoa(bin);
+  const lines: string[] = [];
+  for (let i = 0; i < b64.length; i += 76) {
+    lines.push(b64.slice(i, i + 76));
+  }
+  return lines.join("\r\n");
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
   if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
@@ -336,6 +357,7 @@ serve(async (req) => {
   let sendOk = false;
   let sendErrorCode: string | null = null;
   let sendErrorMessage: string | null = null;
+  const isHtmlBody = looksLikeHtml(body);
 
   if (isResendAccount) {
     // LIT Marketing mailbox — Resend HTTP API, env-scoped key.
@@ -348,16 +370,13 @@ serve(async (req) => {
       const fromLine = account.display_name
         ? `${account.display_name} <${account.email}>`
         : account.email;
-      // Body may already be HTML (composer-authored) or plain text. Detect
-      // so the recipient renders branded markup correctly.
-      const isHtml = /^<[a-z!]/i.test(body.trim()) || /<table|<div|<p[\s>]/i.test(body);
       const payload: Record<string, unknown> = {
         from: fromLine,
         to: [toEmail],
         subject,
         reply_to: account.email,
       };
-      if (isHtml) payload.html = body;
+      if (isHtmlBody) payload.html = body;
       else payload.text = body;
       try {
         const resp = await fetch("https://api.resend.com/emails", {
@@ -395,9 +414,10 @@ serve(async (req) => {
       `To: ${toEmail}`,
       `Subject: ${subject}`,
       `MIME-Version: 1.0`,
-      `Content-Type: text/plain; charset=UTF-8`,
+      `Content-Type: ${isHtmlBody ? "text/html" : "text/plain"}; charset=UTF-8`,
+      `Content-Transfer-Encoding: base64`,
       ``,
-      body,
+      encodeBodyMimeBase64(body),
     ].join("\r\n");
 
     const encodedMessage = toBase64Url(rawMessage);
@@ -442,7 +462,7 @@ serve(async (req) => {
           body: JSON.stringify({
             message: {
               subject,
-              body: { contentType: "Text", content: body },
+              body: { contentType: isHtmlBody ? "HTML" : "Text", content: body },
               toRecipients: [{ emailAddress: { address: toEmail } }],
             },
             saveToSentItems: true,
@@ -471,7 +491,7 @@ serve(async (req) => {
   if (sendOk) {
     await writeTestRow(account.id, account.provider, account.email, "sent", {
       message_id: messageId,
-      metadata: { provider: account.provider, to: toEmail },
+      metadata: { provider: account.provider, to: toEmail, content_type: isHtmlBody ? "html" : "text" },
     });
     await writeHistoryRow(account.provider, "test_sent", "sent", messageId, campaignId);
     // Touch last_synced_at.
@@ -491,6 +511,7 @@ serve(async (req) => {
     await writeTestRow(account.id, account.provider, account.email, "failed", {
       error_code: sendErrorCode,
       error_message: sendErrorMessage,
+      metadata: { content_type: isHtmlBody ? "html" : "text" },
     });
     await writeHistoryRow(account.provider, "test_failed", "failed", null, campaignId);
 


### PR DESCRIPTION
## Summary
- Keep the seven campaign KPI cards visible in draft and launched states instead of swapping drafts to a single summary card.
- Rehydrate saved step-level schedule hints (`time_of_day_local`, `weekdays_only`) when reopening a campaign, so fixed fire times like 9:00 AM do not disappear from the builder.
- Send Gmail test emails as proper HTML MIME when the campaign body is HTML, with base64 transfer encoding; Outlook test sends now also use HTML when appropriate.

## Notes
- Local `gh`/filesystem verification was blocked by the Codex sandbox, so I verified scope with the GitHub compare API.
- Production campaign Gmail sends already had the HTML MIME path; this fixes the test-send path that still forced `text/plain`.