### PR TITLE
Fix LIT contact discovery via Lemlist

### DIFF
--- a/frontend/src/components/command-center/ContactsPanel.tsx
+++ b/frontend/src/components/command-center/ContactsPanel.tsx
@@ -109,7 +109,7 @@ export default function ContactsPanel() {
         const patch = { enrichment_status: 'pending', enrichment_provider: result.provider || 'lemlist' } as Partial<ContactCore>;
         setRows((prev) => (prev || []).map((c) => (c.id === contact.id ? { ...c, ...patch } : c)));
         if (selectedContact?.id === contact.id) setSelectedContact({ ...contact, ...patch });
-        toast.success('Enrichment submitted', { description: 'Lemlist is enriching this profile. Results will appear after the enrichment job completes.' });
+        toast.success('Enrichment submitted', { description: 'LIT is enriching this profile. Results will appear after the enrichment job completes.' });
         return;
       }
 
@@ -131,11 +131,11 @@ export default function ContactsPanel() {
 
   const handleExportCsv = () => {
     if (!filteredRows.length) return;
-    const header = ["name","title","department","seniority","email","phone","linkedin","location","provider"];
+    const header = ["name","title","department","seniority","email","phone","linkedin","location"];
     const csv = [header.join(",")].concat(
       filteredRows.map((r) => [
         contactName(r), r.title ?? "", r.department ?? "", r.seniority ?? "", r.email ?? "",
-        r.direct_dial || r.mobile_phone || r.phone || "", r.linkedin_url || r.linkedin || "", r.location ?? "", r.enrichment_provider || r.source_provider || "",
+        r.direct_dial || r.mobile_phone || r.phone || "", r.linkedin_url || r.linkedin || "", r.location ?? "",
       ].map(escapeCsv).join(","))
     ).join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
@@ -160,7 +160,7 @@ export default function ContactsPanel() {
             <div>
               <div className="flex items-center gap-2 text-cyan-200"><UsersRound className="h-4 w-4" /><span className="text-xs font-bold uppercase tracking-wide">Contact Intelligence</span></div>
               <h3 className="mt-1 text-xl font-bold">Decision-makers at {selected?.name || 'this company'}</h3>
-              <p className="mt-1 text-sm text-slate-300">Lemlist enrichment first, Apollo fallback for verified contact discovery.</p>
+              <p className="mt-1 text-sm text-slate-300">Find verified decision-makers, enrich selected profiles, and keep contacts ready for outreach.</p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <EnrichmentCreditsBadge />

--- a/frontend/src/components/company/CDPContacts.tsx
+++ b/frontend/src/components/company/CDPContacts.tsx
@@ -25,6 +25,7 @@ import {
   updateCompany,
   addCompanyToCampaign,
   getCrmCampaigns,
+  saveContact,
   type ApolloContactPreview,
 } from "@/lib/api";
 import { enrichContact as enrichKnownContact } from "@/lib/enrichment/contactEnrichment";
@@ -326,7 +327,7 @@ export default function CDPContacts({
     try {
       const targets = contacts.filter((c) => c.email || c.linkedin_url || c.full_name || c.name);
       if (targets.length === 0) {
-        setEnrichToast("Add a known contact first, then enrich it with Lemlist.");
+        setEnrichToast("Find or add a contact first, then enrich it with LIT.");
         return;
       }
       await Promise.allSettled(
@@ -441,28 +442,114 @@ export default function CDPContacts({
   async function handleApolloSearch() {
     if (apolloLoading) return;
     setApolloOpen(true);
-    setApolloLoading(false);
+    setApolloLoading(true);
     setApolloError(null);
-    setApolloSetupRequired(true);
-    setApolloSearched(true);
+    setApolloSetupRequired(false);
+    setApolloSearched(false);
     setApolloSelected(new Set());
     setSearchMatchMode(null);
     setSearchOrgMatch(null);
     setApolloPage(1);
     setApolloHasMore(false);
-    setApolloResults([]);
-    setApolloError(
-      "Company contact discovery is paused because Apollo is no longer used for contact enrichment. Add a known contact, then enrich it with Lemlist.",
-    );
+    const effectiveDomain = (searchCompanyDomain || "").trim();
+    const effectiveName = (searchCompanyName || "").trim();
+    if (!effectiveDomain && !effectiveName) {
+      setApolloLoading(false);
+      setApolloSearched(true);
+      setApolloError(
+        "Add either a company domain, name, or location before searching contacts.",
+      );
+      setApolloSetupRequired(true);
+      return;
+    }
+    try {
+      const result = await searchApolloContacts({
+        companyId: companyId ?? null,
+        companyName: effectiveName || null,
+        companyDomain: effectiveDomain || null,
+        city: searchCity.trim() || null,
+        state: searchState.trim() || null,
+        country: searchCountry.trim() || null,
+        usePersonLocations,
+        includeSimilarTitles,
+        titles: apolloTitles.length ? apolloTitles : APOLLO_DEFAULT_TITLES,
+        seniorities: apolloSeniorities.length
+          ? apolloSeniorities
+          : APOLLO_DEFAULT_SENIORITIES,
+        departments: apolloDepartments,
+        perPage: 50,
+      });
+      setApolloSearched(true);
+      setSearchMatchMode(result.matchMode ?? null);
+      setSearchOrgMatch(result.organization ?? null);
+      if (!result.ok) {
+        setApolloResults([]);
+        setApolloError(result.error || "Contact search failed.");
+        setApolloSetupRequired(Boolean(result.setupRequired));
+      } else {
+        setApolloResults(result.contacts);
+        setApolloHasMore(result.contacts.length >= 50);
+        if (result.contacts.length === 0 && result.message) {
+          setApolloError(result.message);
+          setApolloSetupRequired(false);
+        }
+      }
+    } catch (err: any) {
+      setApolloSearched(true);
+      setApolloResults([]);
+      setApolloError(err?.message || "Contact search failed.");
+    } finally {
+      setApolloLoading(false);
+    }
   }
 
   async function handleApolloLoadMore() {
     if (apolloLoadingMore || apolloLoading) return;
     setApolloLoadingMore(true);
     setApolloError(null);
-    setApolloHasMore(false);
-    setApolloLoadingMore(false);
-    setApolloError("Company contact discovery is paused because Apollo is no longer used.");
+    const nextPage = apolloPage + 1;
+    try {
+      const result = await searchApolloContacts({
+        companyId: companyId ?? null,
+        companyName: (searchCompanyName || "").trim() || null,
+        companyDomain: (searchCompanyDomain || "").trim() || null,
+        city: searchCity.trim() || null,
+        state: searchState.trim() || null,
+        country: searchCountry.trim() || null,
+        usePersonLocations,
+        includeSimilarTitles,
+        titles: apolloTitles.length ? apolloTitles : APOLLO_DEFAULT_TITLES,
+        seniorities: apolloSeniorities.length
+          ? apolloSeniorities
+          : APOLLO_DEFAULT_SENIORITIES,
+        departments: apolloDepartments,
+        perPage: 50,
+        page: nextPage,
+      });
+      if (result.ok && Array.isArray(result.contacts)) {
+        if (result.contacts.length === 0) {
+          setApolloHasMore(false);
+        } else {
+          setApolloResults((prev) => {
+            const seen = new Set(
+              prev.map((p: any) => p.apollo_person_id || `${p.full_name}|${p.title}`),
+            );
+            const fresh = result.contacts.filter(
+              (p: any) => !seen.has(p.apollo_person_id || `${p.full_name}|${p.title}`),
+            );
+            return [...prev, ...fresh];
+          });
+          setApolloPage(nextPage);
+          setApolloHasMore(result.contacts.length >= 50);
+        }
+      } else {
+        setApolloError(result.error || "Load more failed.");
+      }
+    } catch (err: any) {
+      setApolloError(err?.message || "Load more failed.");
+    } finally {
+      setApolloLoadingMore(false);
+    }
   }
 
   function toggleApolloSelected(key: string) {
@@ -484,11 +571,66 @@ export default function CDPContacts({
 
   async function handleApolloEnrichSelected() {
     if (apolloEnriching) return;
-    setApolloEnriching(true);
-    setApolloEnrichError(
-      "Add the contact to this company first, then enrich it with Lemlist from the saved contact row.",
+    if (apolloSelected.size === 0) {
+      setApolloEnrichError("Select contacts before enriching.");
+      return;
+    }
+    if (!companyId) {
+      setApolloEnrichError("Save this company before enriching contacts.");
+      return;
+    }
+    const picked = apolloResults.filter((p, i) =>
+      apolloSelected.has(apolloKey(p, i)),
     );
-    setApolloEnriching(false);
+    setApolloEnriching(true);
+    setApolloEnrichError(null);
+    try {
+      const savedRows: Contact[] = [];
+      for (const p of picked) {
+        const fullName =
+          p.full_name ||
+          [p.first_name, p.last_name].filter(Boolean).join(" ").trim();
+        const nameParts = fullName.split(/\s+/).filter(Boolean);
+        const saved = await saveContact(companyId, {
+          first_name: p.first_name || nameParts[0] || "",
+          last_name: p.last_name || nameParts.slice(1).join(" ") || "",
+          title: p.title || "",
+          email: "",
+          phone: "",
+          linkedin_url: p.linkedin_url || "",
+          department: p.department || "",
+        });
+        savedRows.push(saved as Contact);
+        await enrichKnownContact({
+          contactId: saved.id ? String(saved.id) : undefined,
+          fullName: saved.full_name || fullName || undefined,
+          companyName: companyName || p.company || undefined,
+          companyDomain: companyDomain || undefined,
+          linkedinUrl: p.linkedin_url || undefined,
+          title: p.title || undefined,
+          revealPhoneNumber: false,
+        });
+      }
+      setContacts((prev) => {
+        const next = [...savedRows, ...prev];
+        onContactsChanged?.(next);
+        return next;
+      });
+      setApolloResults((prev) =>
+        prev.map((p, i) =>
+          apolloSelected.has(apolloKey(p, i))
+            ? { ...p, enrichment_status: "enriched" as const }
+            : p,
+        ),
+      );
+      setApolloSelected(new Set());
+      setEnrichToast(`Submitted ${savedRows.length} contact${savedRows.length === 1 ? "" : "s"} for LIT enrichment`);
+      setTimeout(() => setEnrichToast(null), 3500);
+    } catch (err: any) {
+      setApolloEnrichError(err?.message || "Contact enrichment failed.");
+    } finally {
+      setApolloEnriching(false);
+    }
   }
 
   // Row-level action handlers
@@ -521,7 +663,7 @@ export default function CDPContacts({
         revealPhoneNumber: false,
       });
       if (!lemlistResult.success) {
-        setEnrichToast(lemlistResult.error || "Lemlist enrichment returned no match.");
+        setEnrichToast(lemlistResult.error || "LIT enrichment returned no match.");
         setTimeout(() => setEnrichToast(null), 3000);
         return;
       }
@@ -533,7 +675,7 @@ export default function CDPContacts({
               : x,
           ),
         );
-        setEnrichToast("Lemlist enrichment submitted.");
+        setEnrichToast("LIT enrichment submitted.");
         setTimeout(() => setEnrichToast(null), 3000);
         return;
       }
@@ -552,7 +694,7 @@ export default function CDPContacts({
           ),
         );
       }
-      setEnrichToast("Contact enriched with Lemlist");
+      setEnrichToast("Contact enriched with LIT");
       setTimeout(() => setEnrichToast(null), 2500);
     } catch (err: any) {
       setEnrichToast(err?.message || "Enrichment failed.");
@@ -561,7 +703,7 @@ export default function CDPContacts({
   }
 
   async function handleRowRevealPhone(_c: Contact) {
-    setEnrichToast("Phone enrichment is not enabled for Lemlist yet. Email enrichment remains active.");
+    setEnrichToast("Phone enrichment is not enabled yet. Email enrichment remains active.");
     setTimeout(() => setEnrichToast(null), 3500);
   }
 
@@ -660,7 +802,7 @@ export default function CDPContacts({
         </button>
         <button
           type="button"
-          onClick={() => setAddOpen(true)}
+          onClick={handleApolloSearch}
           disabled={apolloLoading}
           className="font-display inline-flex items-center gap-1.5 whitespace-nowrap rounded-md bg-gradient-to-b from-violet-500 to-violet-600 px-3 py-1.5 text-[11px] font-semibold text-white shadow-sm hover:from-violet-600 hover:to-violet-700 disabled:cursor-not-allowed disabled:opacity-60"
         >
@@ -670,8 +812,8 @@ export default function CDPContacts({
             <Sparkles className="h-3 w-3" />
           )}
           {contacts.length === 0
-            ? "Add contact to enrich"
-            : "Add another contact"}
+            ? "Find contacts with LIT"
+            : "Find more contacts"}
         </button>
       </div>
 
@@ -994,7 +1136,7 @@ function ContactRow({
           contact.phone
         ) : contact.phone_unlock_status === "pending" ? (
           <span
-            title="Phone enrichment is not enabled for Lemlist yet."
+            title="Phone enrichment is not enabled yet."
             className="font-display inline-flex items-center gap-1 rounded-sm border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.04em] text-amber-700"
           >
             <Loader2 className="h-2.5 w-2.5 animate-spin" />
@@ -1002,7 +1144,7 @@ function ContactRow({
           </span>
         ) : contact.phone_unlock_status === "failed" ? (
           <span
-            title="Phone enrichment is not enabled for Lemlist yet."
+            title="Phone enrichment is not enabled yet."
             className="font-display inline-flex items-center gap-1 rounded-sm border border-rose-200 bg-rose-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.04em] text-rose-700"
           >
             No phone
@@ -1011,7 +1153,7 @@ function ContactRow({
           <button
             type="button"
             onClick={() => handlers.onRevealPhone(contact)}
-            title="Phone enrichment is not enabled for Lemlist yet."
+            title="Phone enrichment is not enabled yet."
             className="font-display inline-flex items-center gap-1 rounded-sm border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.04em] text-slate-500 hover:bg-slate-100"
           >
             <Phone className="h-2.5 w-2.5" />
@@ -1024,13 +1166,13 @@ function ContactRow({
       </td>
       <td className="font-display px-3.5 py-2.5 text-[10px] font-semibold text-slate-500">
         {source ? (
-          /apollo|lit/i.test(String(source)) ? (
+          /apollo|lemlist|lusha|lit/i.test(String(source)) ? (
             <span className="inline-flex items-center gap-1 rounded border border-violet-200 bg-violet-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.04em] text-violet-700">
               <Sparkles className="h-2.5 w-2.5" />
               LIT
             </span>
           ) : (
-            String(source)
+            "LIT"
           )
         ) : (
           "—"

--- a/frontend/src/components/company/CompanyDrawer.tsx
+++ b/frontend/src/components/company/CompanyDrawer.tsx
@@ -95,7 +95,7 @@ export default function CompanyDrawer({ company, open, onOpenChange }: Props) {
 
           {!isImportYeti && (
             <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-              ImportYeti shipment data is only available for Shippers. Save this company and check back once Lusha is live.
+              Shipment data is only available for Shippers. Save this company and check back once enrichment is live.
             </div>
           )}
 

--- a/frontend/src/components/contacts/ContactCard.tsx
+++ b/frontend/src/components/contacts/ContactCard.tsx
@@ -23,8 +23,8 @@ const getEnrichmentStatusColor = (status?: string) => {
   }
 };
 
-const getEnrichmentStatusLabel = (status?: string, provider?: string) => {
-  if (status === 'complete') return provider ? `${provider} enriched` : 'Enriched';
+const getEnrichmentStatusLabel = (status?: string) => {
+  if (status === 'complete') return 'LIT enriched';
   if (status === 'partial') return 'Partially enriched';
   if (status === 'submitted' || status === 'pending') return 'Enrichment pending';
   return 'Not enriched';
@@ -49,7 +49,6 @@ export default function ContactCard({ contact, onViewProfile, onEnrich, index = 
   const resolvedCompanyId = companyId || contact.company_id || undefined;
   const canAddToList = Boolean(contact.id);
   const name = displayName(contact);
-  const provider = contact.enrichment_provider || contact.source_provider;
   const linkedIn = linkedinUrl(contact);
   const phone = contact.direct_dial || contact.mobile_phone || contact.phone;
 
@@ -81,7 +80,7 @@ export default function ContactCard({ contact, onViewProfile, onEnrich, index = 
             </div>
           </div>
           <span className={`flex-shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-semibold capitalize ${getEnrichmentStatusColor(contact.enrichment_status)}`}>
-            {getEnrichmentStatusLabel(contact.enrichment_status, provider)}
+            {getEnrichmentStatusLabel(contact.enrichment_status)}
           </span>
         </div>
 

--- a/frontend/src/components/contacts/ContactProfileModal.tsx
+++ b/frontend/src/components/contacts/ContactProfileModal.tsx
@@ -20,7 +20,6 @@ function enrichedFields(contact: ContactCore) {
   const result = (contact.enrichment_result || {}) as Record<string, unknown>;
   return [
     ['Company', contact.company_name || result.companyName],
-    ['Provider', contact.enrichment_provider || contact.source_provider],
     ['Personal email', contact.personal_email || result.personalEmail],
     ['Profile image', avatarUrl(contact) ? 'Available' : null],
   ].filter(([, value]) => Boolean(value));
@@ -37,7 +36,6 @@ export default function ContactProfileModal({ isOpen, contact, onClose, onEnrich
   const linkedIn = linkedinUrl(contact);
   const phone = contact.direct_dial || contact.mobile_phone || contact.phone;
   const extraFields = enrichedFields(contact);
-  const provider = contact.enrichment_provider || contact.source_provider;
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -64,7 +62,7 @@ export default function ContactProfileModal({ isOpen, contact, onClose, onEnrich
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="mb-2 flex flex-wrap items-center gap-2">
-                    {provider && <span className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-semibold text-cyan-100">{provider}</span>}
+                    {(contact.enrichment_provider || contact.source_provider) && <span className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-semibold text-cyan-100">LIT enriched</span>}
                     {contact.enrichment_status && <span className="rounded-full border border-white/15 bg-white/10 px-2.5 py-1 text-xs font-semibold capitalize text-white/85">{contact.enrichment_status}</span>}
                   </div>
                   <h2 className="truncate text-2xl font-bold tracking-tight">{name}</h2>

--- a/frontend/src/components/lists/BulkEnrichButton.jsx
+++ b/frontend/src/components/lists/BulkEnrichButton.jsx
@@ -318,7 +318,7 @@ export default function BulkEnrichButton({ list }) {
           Enrich contacts for all companies
         </h3>
         <p className="mt-1 text-[12.5px] text-slate-600">
-          Estimated ~{estimateMins} minutes · ~{estimateCredits} Apollo credits ·
+          Estimated ~{estimateMins} minutes · ~{estimateCredits} enrichment credits ·
           Finds decision-makers and syncs them to Attio automatically.
         </p>
         <button

--- a/frontend/src/components/settings/SettingsSections.tsx
+++ b/frontend/src/components/settings/SettingsSections.tsx
@@ -1952,7 +1952,7 @@ export function IntegrationsHubSection(props: {
       {/* Enrichment card */}
       <SCard
         title="Enrichment"
-        subtitle="Apollo, Lusha, or Hunter contact enrichment providers."
+        subtitle="LIT contact enrichment."
         right={
           <SBadge tone={enrichmentRows.length > 0 ? "green" : "slate"} dot>
             {enrichmentRows.length > 0 ? `${enrichmentRows.length} connected` : "Not connected"}

--- a/frontend/src/features/admin/AdminPanels.tsx
+++ b/frontend/src/features/admin/AdminPanels.tsx
@@ -1115,7 +1115,7 @@ export function IngestionStatus() {
 
       const overrides: Record<string, { last: string | null; tone?: "ok" | "warning" | "stale" }> = {
         "ImportYeti · BOL feed": { last: (importYetiLast.data as any)?.updated_at ?? null },
-        "Apollo enrichment · contacts": { last: (contactsLast.data as any)?.updated_at ?? null },
+        "LIT enrichment · contacts": { last: (contactsLast.data as any)?.updated_at ?? null },
         "Clay enrichment · companies": { last: (companiesLast.data as any)?.updated_at ?? null },
       };
 

--- a/frontend/src/features/pulse/PulseQuickCard.jsx
+++ b/frontend/src/features/pulse/PulseQuickCard.jsx
@@ -1125,7 +1125,7 @@ function DecisionMakersPanel({
             type="button"
             onClick={() => onFetch({ force: true, applyFilters: hasCustomFilters })}
             className="font-display inline-flex items-center gap-1 text-[10px] font-semibold text-slate-500 hover:text-slate-700"
-            title="Bypass cache and re-query Apollo"
+            title="Bypass cache and re-query contacts"
           >
             <RefreshCw className="h-2.5 w-2.5" />
             Re-fetch
@@ -1175,9 +1175,9 @@ function DecisionMakersPanel({
                     ) : c.email_status === 'locked' ? (
                       <span
                         className="font-body text-[10.5px] italic text-amber-600"
-                        title="Apollo found this contact but their email is gated behind a paid unlock credit."
+                        title="LIT found this contact, but email enrichment is not available yet."
                       >
-                        Email locked — Apollo plan limit
+                        Email not available yet
                       </span>
                     ) : (
                       <span className="font-body text-[10.5px] italic text-slate-400">

--- a/frontend/src/features/pulse/PulseResults.jsx
+++ b/frontend/src/features/pulse/PulseResults.jsx
@@ -86,14 +86,12 @@ export function PermissionIssueState({ message }) {
           <ShieldAlert className='h-5 w-5 text-orange-600' />
         </div>
         <div className='min-w-0'>
-          <h3 className='text-sm font-semibold text-orange-900'>Apollo API permission issue</h3>
+          <h3 className='text-sm font-semibold text-orange-900'>Contact search permission issue</h3>
           <p className='mt-1 text-sm leading-6 text-orange-800'>
-            Your API key exists, but Apollo rejected the endpoint. This usually means the current
-            Apollo plan or API scopes do not allow this search endpoint.
+            The contact search key exists, but the search endpoint rejected the request.
           </p>
           <p className='mt-2 text-sm leading-6 text-orange-800'>
-            Enable Apollo prospecting API access on the key (or upgrade the plan), or import data
-            into your Apollo CRM so the fallback CRM endpoints return results.
+            Confirm contact search access is enabled for this workspace, or import contacts directly into LIT.
           </p>
           {message ? (
             <pre className='mt-3 overflow-x-auto rounded-lg bg-white/70 p-3 font-mono text-[11px] text-orange-900'>

--- a/frontend/src/features/settings/components/OrgEnrichmentSettingsPanel.tsx
+++ b/frontend/src/features/settings/components/OrgEnrichmentSettingsPanel.tsx
@@ -81,23 +81,23 @@ type EnrichmentSettings = {
 };
 
 const DEFAULTS: EnrichmentSettings = {
-  provider_order: ["lemlist", "apollo"],
+  provider_order: ["lemlist"],
   enable_tier3: false,
 };
 
 const PROVIDER_LABEL: Record<ProviderName, string> = {
-  lemlist: "Lemlist",
-  apollo: "Apollo fallback",
-  tier3: "Tier-3 (ZoomInfo / Cognism)",
+  lemlist: "Primary enrichment",
+  apollo: "Legacy discovery only",
+  tier3: "Enterprise fallback",
 };
 
 const PROVIDER_BLURB: Record<ProviderName, string> = {
-  lemlist: "Primary enrichment path for email, phone, LinkedIn, verification, and campaign-ready profile data.",
-  apollo: "Fallback for discovery and enrichment gaps when Lemlist does not return a match.",
+  lemlist: "Primary path for email, LinkedIn, verification, and campaign-ready profile data.",
+  apollo: "Not used for contact enrichment. Reserved only for legacy discovery flows.",
   tier3: "Premium fallback for enterprise targets. Disabled until credentials are configured.",
 };
 
-const VALID_PROVIDERS: ProviderName[] = ["lemlist", "apollo", "tier3"];
+const VALID_PROVIDERS: ProviderName[] = ["lemlist", "tier3"];
 
 function normalizeProviderOrder(rawOrder: string[]): ProviderName[] {
   const seen = new Set<ProviderName>();
@@ -211,7 +211,7 @@ export default function OrgEnrichmentSettingsPanel({
         Enrichment provider order
       </h2>
       <p style={{ fontSize: 13, color: "#64748b", margin: "0 0 16px" }}>
-        Contact enrichment uses Lemlist first, then falls back only when needed. Reorder the cascade if your hit-rate data changes.
+        Contact enrichment uses LIT enrichment only. Legacy discovery is not used as an enrichment fallback.
       </p>
 
       <div style={{ borderTop: "1px solid #e2e8f0", marginBottom: 16 }}>
@@ -334,7 +334,7 @@ export default function OrgEnrichmentSettingsPanel({
         <div>
           <div style={{ fontSize: 13, color: "#0f172a", fontWeight: 500 }}>Enable Tier-3 provider</div>
           <div style={{ fontSize: 11, color: "#94a3b8", marginTop: 2 }}>
-            ZoomInfo / Cognism cascade fallback. Returns no contacts until provider credentials are configured.
+            Enterprise cascade fallback. Returns no contacts until provider credentials are configured.
           </div>
         </div>
         <label style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5054,7 +5054,7 @@ export type ApolloContactPreview = {
   phone?: string | null;
   linkedin_url?: string | null;
   email_status?: string | null;
-  source?: "apollo";
+  source?: "apollo" | "lemlist";
   enrichment_status?: "preview" | "enriched" | "failed";
 };
 
@@ -5105,7 +5105,7 @@ export async function searchApolloContacts(
     per_page: payload.perPage ?? 25,
   };
   const { data, error } = await supabase.functions.invoke(
-    "apollo-contact-search",
+    "lemlist-contact-search",
     { body: requestBody },
   );
   if (error) {
@@ -5186,7 +5186,7 @@ export async function searchApolloContacts(
         ([p.city, p.state, p.country].filter(Boolean).join(", ") || null),
       linkedin_url: p.linkedin_url ?? p.linkedin ?? null,
       email_status: p.email_status ?? null,
-      source: "apollo",
+      source: p.source === "lemlist" ? "lemlist" : "apollo",
       enrichment_status: "preview",
     };
   });

--- a/frontend/src/pages/AdminMarketingAnalytics.tsx
+++ b/frontend/src/pages/AdminMarketingAnalytics.tsx
@@ -144,7 +144,7 @@ export default function AdminMarketingAnalytics() {
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-blue-600"><BarChart3 className="h-4 w-4" /><span className="text-[11px] font-bold uppercase tracking-[0.14em]" style={{ fontFamily: fontDisplay }}>Admin marketing analytics</span></div>
             <h1 className="mt-1.5 text-[28px] font-bold tracking-[-0.02em] text-slate-950" style={{ fontFamily: fontDisplay }}>Customer acquisition command center</h1>
-            <p className="mt-1.5 max-w-3xl text-[13.5px] leading-relaxed text-slate-500">A unified view of marketing email, LinkedIn, Lemlist enrichment, and the opportunity funnel. This page is admin-only.</p>
+            <p className="mt-1.5 max-w-3xl text-[13.5px] leading-relaxed text-slate-500">A unified view of marketing email, LinkedIn, LIT enrichment, and the opportunity funnel. This page is admin-only.</p>
           </div>
           <div className="flex items-center gap-2">
             <div className="inline-flex h-9 items-center rounded-lg border border-slate-200 bg-white p-1 shadow-sm">
@@ -161,17 +161,17 @@ export default function AdminMarketingAnalytics() {
             <div className="p-6">
               <div className="flex items-center gap-2 text-cyan-200"><Target className="h-4 w-4" /><span className="text-xs font-bold uppercase tracking-wide">Opportunity flow</span></div>
               <h2 className="mt-2 text-2xl font-bold" style={{ fontFamily: fontDisplay }}>From prospect to customer</h2>
-              <p className="mt-1 text-sm text-slate-300">Resend, outbound campaign engagement, and Lemlist activity roll into one acquisition pipeline.</p>
+              <p className="mt-1 text-sm text-slate-300">Outbound campaign engagement and LIT enrichment activity roll into one acquisition pipeline.</p>
               <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-6">
                 {STAGES.map((stage) => <FunnelTile key={stage.key} label={stage.label} value={stageCounts.get(stage.key) || 0} />)}
               </div>
             </div>
             <div className="border-t border-white/10 bg-white/5 p-6 lg:border-l lg:border-t-0">
-              <div className="flex items-center gap-2 text-cyan-200"><Sparkles className="h-4 w-4" /><span className="text-xs font-bold uppercase tracking-wide">Lemlist</span></div>
+              <div className="flex items-center gap-2 text-cyan-200"><Sparkles className="h-4 w-4" /><span className="text-xs font-bold uppercase tracking-wide">LIT enrichment</span></div>
               <div className="mt-3 text-3xl font-bold tabular-nums">{fmtInt(lemlistEvents)}</div>
-              <p className="mt-1 text-sm text-slate-300">Lemlist-sourced opportunities in this window</p>
+              <p className="mt-1 text-sm text-slate-300">Enrichment-sourced opportunities in this window</p>
               <div className="mt-4 rounded-lg border border-white/10 bg-white/10 p-3 text-sm">
-                <div className="font-semibold">{latestCampaign?.name || "No Lemlist campaign found"}</div>
+                <div className="font-semibold">{latestCampaign?.name || "No acquisition campaign found"}</div>
                 {latestCampaign && <div className="mt-1 text-slate-300">Status: {latestCampaign.status} · Last sync {fmtRelative(latestCampaign.last_synced_at)}</div>}
               </div>
             </div>
@@ -196,7 +196,7 @@ export default function AdminMarketingAnalytics() {
             </Card>
           </div>
           <div className="space-y-6">
-            <Card title="Enrichment jobs" subtitle="Lemlist primary, Apollo fallback">
+            <Card title="Enrichment jobs" subtitle="LIT enrichment activity">
               <JobList jobs={enrichmentJobs} />
             </Card>
             <Card title="LinkedIn performance" subtitle={`Last ${days} days`}>
@@ -228,7 +228,7 @@ function Card({ title, subtitle, children }: { title: string; subtitle?: string;
 
 function Table({ rows }: { rows: OpportunityRow[] }) {
   if (!rows.length) return <Empty title="No opportunities yet" text="Events will appear here as prospects engage, reply, book meetings, and convert." />;
-  return <div className="overflow-x-auto"><table className="w-full"><thead><tr><Th>Contact</Th><Th>Company</Th><Th>Stage</Th><Th>Source</Th><Th align="right">Updated</Th></tr></thead><tbody>{rows.map((row) => <tr key={row.id} className="border-t border-slate-100 hover:bg-slate-50"><Td><div className="font-semibold text-slate-900">{row.contact_name || row.email || "Unknown"}</div><div className="text-xs text-slate-500">{row.title || row.email}</div></Td><Td>{row.company_name || "-"}</Td><Td><span className="rounded-full bg-blue-50 px-2 py-1 text-xs font-semibold capitalize text-blue-700">{row.stage.replace(/_/g, " ")}</span></Td><Td>{row.source_provider || "manual"}</Td><Td align="right">{fmtRelative(row.stage_changed_at)}</Td></tr>)}</tbody></table></div>;
+  return <div className="overflow-x-auto"><table className="w-full"><thead><tr><Th>Contact</Th><Th>Company</Th><Th>Stage</Th><Th>Source</Th><Th align="right">Updated</Th></tr></thead><tbody>{rows.map((row) => <tr key={row.id} className="border-t border-slate-100 hover:bg-slate-50"><Td><div className="font-semibold text-slate-900">{row.contact_name || row.email || "Unknown"}</div><div className="text-xs text-slate-500">{row.title || row.email}</div></Td><Td>{row.company_name || "-"}</Td><Td><span className="rounded-full bg-blue-50 px-2 py-1 text-xs font-semibold capitalize text-blue-700">{row.stage.replace(/_/g, " ")}</span></Td><Td>{row.source_provider ? "LIT" : "Direct"}</Td><Td align="right">{fmtRelative(row.stage_changed_at)}</Td></tr>)}</tbody></table></div>;
 }
 
 function Th({ children, align = "left" }: { children: React.ReactNode; align?: "left" | "right" }) {
@@ -246,8 +246,8 @@ function DailyBars({ data, loading }: { data: Array<{ day: string; sent: number;
 }
 
 function JobList({ jobs }: { jobs: EnrichmentJobRow[] }) {
-  if (!jobs.length) return <Empty title="No enrichment jobs" text="Lemlist enrichment submissions will appear here." />;
-  return <ul className="divide-y divide-slate-100">{jobs.map((job) => <li key={job.id} className="px-5 py-3"><div className="flex items-center justify-between gap-3"><div><div className="text-sm font-semibold text-slate-900">{job.provider}</div><div className="text-xs text-slate-500">{job.source_context} · {(job.workflows || []).join(", ")}</div></div><div className="text-right"><div className="text-xs font-semibold capitalize text-slate-700">{job.status}</div><div className="text-[11px] text-slate-400" style={{ fontFamily: fontMono }}>{fmtRelative(job.created_at)}</div></div></div></li>)}</ul>;
+  if (!jobs.length) return <Empty title="No enrichment jobs" text="LIT enrichment submissions will appear here." />;
+  return <ul className="divide-y divide-slate-100">{jobs.map((job) => <li key={job.id} className="px-5 py-3"><div className="flex items-center justify-between gap-3"><div><div className="text-sm font-semibold text-slate-900">LIT enrichment</div><div className="text-xs text-slate-500">{job.source_context} · {(job.workflows || []).join(", ")}</div></div><div className="text-right"><div className="text-xs font-semibold capitalize text-slate-700">{job.status}</div><div className="text-[11px] text-slate-400" style={{ fontFamily: fontMono }}>{fmtRelative(job.created_at)}</div></div></div></li>)}</ul>;
 }
 
 function LinkedInSummary({ data, notConfigured }: { data: LinkedInAnalyticsResponse | null; notConfigured: boolean }) {

--- a/frontend/src/pages/AdminSettings.jsx
+++ b/frontend/src/pages/AdminSettings.jsx
@@ -41,7 +41,7 @@ export default function AdminSettings(){
         <CardPanel title='Third-Party Keys'>
           <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
             <div>
-              <Label htmlFor='apollo'>Apollo.io API Key</Label>
+              <Label htmlFor='apollo'>Contact search API key</Label>
               <Input id='apollo' type='password' placeholder='••••••••' value={third.apollo} onChange={(e)=>setThird(v=>({...v, apollo:e.target.value}))}/>
             </div>
             <div>

--- a/frontend/src/pages/LeadProspecting.jsx
+++ b/frontend/src/pages/LeadProspecting.jsx
@@ -45,42 +45,42 @@ const TYPEWRITER_EXAMPLES = [
 const PROVIDERS = [
   {
     key: 'apollo',
-    name: 'Apollo',
+    name: 'LIT search',
     role: 'Broad company & contact search',
     icon: Search,
     tier: 'configured',
   },
   {
     key: 'tavily',
-    name: 'Tavily',
+    name: 'Web research',
     role: 'Web research & company context',
     icon: Globe,
     tier: 'configured',
   },
   {
     key: 'hunter',
-    name: 'Hunter',
+    name: 'Email verification',
     role: 'Email discovery & verification',
     icon: Mail,
     tier: 'configured',
   },
   {
     key: 'lusha',
-    name: 'Lusha',
+    name: 'Contact enrichment',
     role: 'Contact enrichment (email + phone)',
     icon: UserRound,
     tier: 'optional',
   },
   {
     key: 'phantombuster',
-    name: 'PhantomBuster',
+    name: 'LinkedIn workflows',
     role: 'User-authorized LinkedIn workflows (rate-limited)',
     icon: Network,
     tier: 'optional',
   },
   {
     key: 'explorium',
-    name: 'Explorium',
+    name: 'Firmographic API',
     role: 'Firmographic + prospect API',
     icon: Layers,
     tier: 'paused',
@@ -95,13 +95,13 @@ const TUTORIAL_STEPS = [
   },
   {
     icon: Search,
-    title: 'Apollo + Tavily search',
-    body: 'Pulse queries Apollo for companies and people, and Tavily for web research and company context.',
+    title: 'LIT search and research',
+    body: 'Pulse queries LIT for companies and people, then adds web research and company context.',
   },
   {
     icon: Sparkles,
     title: 'Verify and enrich',
-    body: 'Resolve and verify emails with Hunter (and Lusha when configured) only on the rows you act on. No bulk credit burn.',
+    body: 'Resolve and verify emails only on the rows you act on. No bulk credit burn.',
   },
   {
     icon: Send,
@@ -459,14 +459,12 @@ function PermissionIssueState({ message }) {
           <ShieldAlert className='h-5 w-5 text-orange-600' />
         </div>
         <div className='min-w-0'>
-          <h3 className='text-sm font-semibold text-orange-900'>Apollo API permission issue</h3>
+          <h3 className='text-sm font-semibold text-orange-900'>Contact search permission issue</h3>
           <p className='mt-1 text-sm leading-6 text-orange-800'>
-            Your API key exists, but Apollo rejected the endpoint. This usually means the current
-            Apollo plan or API scopes do not allow this search endpoint.
+            The contact search key exists, but the search endpoint rejected the request.
           </p>
           <p className='mt-2 text-sm leading-6 text-orange-800'>
-            Enable Apollo prospecting API access on the key (or upgrade the plan), or import data
-            into your Apollo CRM so the fallback CRM endpoints return results.
+            Confirm contact search access is enabled for this workspace, or import contacts directly into LIT.
           </p>
           {message ? (
             <pre className='mt-3 overflow-x-auto rounded-lg bg-white/70 p-3 font-mono text-[11px] text-orange-900'>

--- a/frontend/src/pages/Pulse.jsx
+++ b/frontend/src/pages/Pulse.jsx
@@ -1303,9 +1303,9 @@ function V2IntentChips({ parsed, sources, apolloCalled }) {
         <span className="text-slate-400 normal-case font-normal tracking-normal">
           {sources?.saved ? `${sources.saved} saved · ` : ''}
           {sources?.directory ? `${sources.directory} LIT · ` : ''}
-          {sources?.apollo ? `${sources.apollo} Apollo · ` : ''}
+          {sources?.apollo ? `${sources.apollo} LIT contacts · ` : ''}
           total {total}
-          {apolloCalled ? '' : ' · Apollo not called'}
+          {apolloCalled ? '' : ' · contact search not called'}
         </span>
       </div>
       <div className="flex flex-wrap gap-1.5">
@@ -1782,7 +1782,7 @@ function BulkSaveBar({ selectedIds, results, savedMemberships, onClear, onSaved,
       } else if (enrichError) {
         parts.push(`(contact enrichment hit an error — companies still synced to Attio)`);
       } else {
-        parts.push(`(Apollo found no decision-maker contacts to enrich — companies still synced to Attio)`);
+        parts.push(`(LIT found no decision-maker contacts to enrich — companies still synced to Attio)`);
       }
       toast.success(parts.join(' · '));
       onSaved?.();

--- a/supabase/functions/lemlist-contact-search/index.ts
+++ b/supabase/functions/lemlist-contact-search/index.ts
@@ -1,0 +1,249 @@
+// lemlist-contact-search - company-scoped People Database discovery.
+//
+// This returns preview contacts only. Email enrichment happens later through
+// lemlist-enrichment after the user selects contacts.
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const LEMLIST_API_KEY =
+  Deno.env.get("LEMLIST_API") ||
+  Deno.env.get("LEMLIST_API_KEY") ||
+  Deno.env.get("Lemlist_API") ||
+  "";
+const LEMLIST_BASE_URL = "https://api.lemlist.com/api";
+
+type SearchBody = {
+  company_id?: string | null;
+  company_name?: string | null;
+  domain?: string | null;
+  titles?: string[] | null;
+  seniorities?: string[] | null;
+  departments?: string[] | null;
+  page?: number | null;
+  per_page?: number | null;
+};
+
+type LemlistFilter = { filterId: string; in: string[]; out: string[] };
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function basicAuthHeader(apiKey: string): string {
+  return `Basic ${btoa(`:${apiKey}`)}`;
+}
+
+function normalizeDomain(value?: string | null): string | null {
+  if (!value) return null;
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .split(/[/?#]/)[0] || null;
+}
+
+function nonEmptyStrings(values?: string[] | null): string[] {
+  return Array.from(
+    new Set(
+      (Array.isArray(values) ? values : [])
+        .map((v) => String(v || "").trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function mapSeniorities(values?: string[] | null): string[] {
+  const out = new Set<string>();
+  for (const value of nonEmptyStrings(values)) {
+    const v = value.toLowerCase();
+    if (v.includes("owner")) out.add("Ownership / Firm Leadership");
+    else if (v.includes("vp") || v.includes("head")) out.add("Executive Leadership");
+    else if (v.includes("director")) out.add("Department Leadership");
+    else if (v.includes("manager")) out.add("People Management / Leadership");
+  }
+  return Array.from(out);
+}
+
+function mapDepartments(values?: string[] | null): string[] {
+  const mapped = new Set<string>();
+  for (const value of nonEmptyStrings(values)) {
+    const v = value.toLowerCase();
+    if (v.includes("procurement") || v.includes("purchasing") || v.includes("sourcing")) mapped.add("Purchasing");
+    else if (
+      v.includes("operation") ||
+      v.includes("logistics") ||
+      v.includes("supply") ||
+      v.includes("transport")
+    ) mapped.add("Operations");
+    else if (v.includes("legal")) mapped.add("Legal");
+  }
+  if (mapped.size === 0) {
+    mapped.add("Operations");
+    mapped.add("Purchasing");
+  }
+  return Array.from(mapped);
+}
+
+function splitName(fullName?: string | null): { first_name: string | null; last_name: string | null } {
+  const parts = String(fullName || "").trim().split(/\s+/).filter(Boolean);
+  return {
+    first_name: parts[0] || null,
+    last_name: parts.slice(1).join(" ") || null,
+  };
+}
+
+function currentExperience(row: any): any {
+  const experiences = Array.isArray(row?.experiences) ? row.experiences : [];
+  return experiences[0] || {};
+}
+
+function inferDepartment(title?: string | null): string | null {
+  const t = String(title || "").toLowerCase();
+  if (/(procurement|purchasing|sourcing)/.test(t)) return "procurement";
+  if (/(legal|counsel|compliance)/.test(t)) return "legal";
+  if (/(logistics|supply|transport|warehouse|distribution|import|customs|operation)/.test(t)) return "operations";
+  return null;
+}
+
+function toLinkedInUrl(row: any): string | null {
+  if (row?.linkedin_url) return row.linkedin_url;
+  if (row?.lead_linkedin_url) return row.lead_linkedin_url;
+  if (row?.canonical_shorthand_name) return `https://www.linkedin.com/in/${row.canonical_shorthand_name}`;
+  return null;
+}
+
+function toPreview(row: any) {
+  const exp = currentExperience(row);
+  const fullName = row?.full_name || row?.name || null;
+  const names = splitName(fullName);
+  const title = row?.current_title || exp?.title || row?.title || null;
+  const company = exp?.company_name || row?.current_company_name || row?.company_name || null;
+  return {
+    apollo_person_id: row?.lead_id ? String(row.lead_id) : row?.id ? String(row.id) : null,
+    full_name: fullName,
+    first_name: row?.first_name || names.first_name,
+    last_name: row?.last_name || names.last_name,
+    title,
+    department: row?.department || inferDepartment(title),
+    seniority: row?.seniority || null,
+    company,
+    location: row?.location || exp?.location || row?.country || null,
+    city: row?.city || null,
+    state: row?.state || null,
+    country_code: row?.country_code || null,
+    phone: null,
+    linkedin_url: toLinkedInUrl(row),
+    email_status: null,
+    source: "lemlist",
+    enrichment_status: "preview",
+  };
+}
+
+async function hydrateCompany(supabase: ReturnType<typeof createClient>, body: SearchBody) {
+  let companyName = body.company_name?.trim() || null;
+  let domain = normalizeDomain(body.domain || null);
+  if (body.company_id && (!companyName || !domain)) {
+    const { data: company } = await supabase
+      .from("lit_companies")
+      .select("id, name, domain, website")
+      .eq("id", body.company_id)
+      .maybeSingle();
+    if (company) {
+      companyName = companyName || company.name || null;
+      domain = domain || normalizeDomain(company.domain || company.website);
+    }
+  }
+  return { companyName, domain };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 200, headers: corsHeaders });
+  if (req.method !== "POST") return json({ ok: false, error: "Method not allowed" }, 405);
+  if (!LEMLIST_API_KEY) return json({ ok: false, error: "LEMLIST_API is not configured", code: "PROVIDER_NOT_CONFIGURED" }, 500);
+
+  const authHeader = req.headers.get("Authorization") || "";
+  if (!authHeader.startsWith("Bearer ")) return json({ ok: false, error: "Missing authorization header", code: "UNAUTHENTICATED" }, 401);
+
+  const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+  const { data: { user }, error: userError } = await supabase.auth.getUser(authHeader.replace("Bearer ", ""));
+  if (userError || !user) return json({ ok: false, error: "Unauthorized", code: "UNAUTHENTICATED" }, 401);
+
+  const body: SearchBody = await req.json().catch(() => ({}));
+  const { companyName, domain } = await hydrateCompany(supabase, body);
+  if (!companyName && !domain) {
+    return json({
+      ok: false,
+      code: "COMPANY_NOT_VERIFIED",
+      message: "LIT could not confirm this company. Add a company name or website before searching contacts.",
+    }, 400);
+  }
+
+  const filters: LemlistFilter[] = [];
+  if (domain) filters.push({ filterId: "currentCompanyWebsiteUrl", in: [domain], out: [] });
+  else if (companyName) filters.push({ filterId: "currentCompany", in: [companyName], out: [] });
+
+  const titles = nonEmptyStrings(body.titles).slice(0, 15);
+  if (titles.length) filters.push({ filterId: "currentTitle", in: titles, out: [] });
+
+  const departments = mapDepartments(body.departments);
+  if (departments.length) filters.push({ filterId: "department", in: departments, out: [] });
+
+  const seniorities = mapSeniorities(body.seniorities);
+  if (seniorities.length) filters.push({ filterId: "seniority", in: seniorities, out: [] });
+
+  const page = Math.max(1, Number(body.page) || 1);
+  const size = Math.min(100, Math.max(1, Number(body.per_page) || 25));
+
+  const res = await fetch(`${LEMLIST_BASE_URL}/database/people`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+      "Authorization": basicAuthHeader(LEMLIST_API_KEY),
+    },
+    body: JSON.stringify({ filters, page, size }),
+  });
+  const rawText = await res.text().catch(() => "");
+  let raw: any = null;
+  try { raw = rawText ? JSON.parse(rawText) : null; } catch { raw = rawText; }
+
+  if (!res.ok) {
+    return json({
+      ok: false,
+      provider: "lit",
+      error: typeof raw === "string" ? raw : raw?.message || raw?.error || "LIT contact search failed",
+      status: res.status,
+    }, res.status);
+  }
+
+  const results = Array.isArray(raw?.results) ? raw.results : [];
+  const contacts = results.map(toPreview).filter((c: any) => c.full_name || c.linkedin_url);
+  const matchMode = domain ? "domain" : "name_location_fallback";
+  const organization = companyName || domain ? { id: null, name: companyName, primary_domain: domain } : null;
+  return json({
+    ok: true,
+    provider: "lit",
+    contacts,
+    people: contacts,
+    total: raw?.totalCount ?? raw?.total ?? contacts.length,
+    has_more: raw?.hasMore === true || contacts.length >= size,
+    matchMode,
+    match_mode: matchMode,
+    organization,
+    apollo_organization: organization,
+    message: contacts.length === 0 ? "No LIT contacts matched this company and role filter." : null,
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the `lemlist-contact-search` Supabase Edge Function for company/domain-based contact discovery with LIT-branded responses.
- Wires the Command Center contact search button back to real company-scoped discovery, selection, save, and enrichment flow.
- Hides upstream source/provider names in customer/admin UI copy and contact cards/drawers.

## Verification
- Deployed `lemlist-contact-search` to Supabase project `jkmrfiaefxwgbvftohrb` with JWT verification enabled.
- Ran `git diff --check` on the scoped files successfully.
- Frontend production build could not run locally because dependencies were not installed and `npm ci` failed with `ENOSPC: no space left on device`; partial `frontend/node_modules` was removed afterward.