### PR TITLE
Consolidate lifecycle emails and add Pulse Coach video

### DIFF
--- a/frontend/src/features/coach/PulseCoachWidget.tsx
+++ b/frontend/src/features/coach/PulseCoachWidget.tsx
@@ -42,13 +42,13 @@ import {
 } from "@/lib/onboardingState";
 
 /**
- * Pulse Coach widget â€” proactive AI nudges grounded in the user's
+ * Pulse Coach widget — proactive AI nudges grounded in the user's
  * workspace state. Two render modes share a single data source:
  *
- *   "floating"  â€” bottom-right pill that expands into a card. Mounted
+ *   "floating"  — bottom-right pill that expands into a card. Mounted
  *                 globally in AppShell so it follows the user across
  *                 every page.
- *   "inline"    â€” full hero panel rendered on the Dashboard.
+ *   "inline"    — full hero panel rendered on the Dashboard.
  *
  * The widget hits the `pulse-coach` edge function which returns LLM-
  * generated nudges + an aggregated workspace_lanes envelope used by
@@ -134,7 +134,7 @@ export function PulseCoachProvider({
   const { user } = useAuth();
   const userId = user?.id || null;
   // Initial render: read cache for the current user only. If the user
-  // is not yet known (auth still warming up) start empty â€” the userId
+  // is not yet known (auth still warming up) start empty — the userId
   // effect below kicks in once auth resolves.
   const [result, setResult] = useState<PulseCoachResult | null>(() => {
     if (typeof window === "undefined") return null;
@@ -167,15 +167,15 @@ export function PulseCoachProvider({
           // and the workspace-lanes list don't reflow on every coach
           // refresh:
           //
-          //   A. Zero-lane response while prev had lanes â†’ keep prev.
+          //   A. Zero-lane response while prev had lanes → keep prev.
           //      Prevents the globe blanking out if the LLM call drops
           //      the lanes block.
           //
-          //   B. Same lane keys as before â†’ reuse the prev array
+          //   B. Same lane keys as before → reuse the prev array
           //      reference. Without this, every refresh produced a new
           //      array (same content, new identity) which forced the
           //      `sorted` / `globeLanes` useMemos to recompute and the
-          //      GlobeCanvas three.js scene to rebuild â€” the visible
+          //      GlobeCanvas three.js scene to rebuild — the visible
           //      "tabs disappear and reflow" symptom on dashboard.
           setResult((prev) => {
             if (!r.ok) return r;
@@ -269,7 +269,7 @@ export function usePulseCoach(): PulseCoachContextValue {
   return ctx;
 }
 
-/* â”€â”€ Action handler â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Action handler ──────────────────────────────────────────────── */
 
 function useNudgeActionHandler() {
   const navigate = useNavigate();
@@ -320,7 +320,7 @@ function useNudgeActionHandler() {
   );
 }
 
-/* â”€â”€ Inline (dashboard hero) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Inline (dashboard hero) ─────────────────────────────────────── */
 
 export function PulseCoachInline() {
   const { result, loading, error, refresh, highlightLane, highlightedLane } =
@@ -390,15 +390,15 @@ export function PulseCoachInline() {
       {/* body */}
       {loading && nudges.length === 0 ? (
         <div className="font-body relative px-1 py-6 text-center text-[12px] text-slate-400">
-          Reading your workspaceâ€¦
+          Reading your workspace…
         </div>
       ) : error && nudges.length === 0 ? (
         <div className="font-body relative px-1 py-4 text-[12px] text-amber-300">
-          Coach is offline â€” {error}
+          Coach is offline — {error}
         </div>
       ) : nudges.length === 0 ? (
         <div className="font-body relative px-1 py-4 text-[12px] text-slate-400">
-          No nudges right now. Try saving a company or enriching a contact â€”
+          No nudges right now. Try saving a company or enriching a contact —
           Coach lights up once there's signal to work with.
         </div>
       ) : (
@@ -436,7 +436,7 @@ export function PulseCoachInline() {
   );
 }
 
-/* â”€â”€ Plan + usage warning â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Plan + usage warning ───────────────────────────────────────── */
 
 const PLAN_PULSE_LIMITS: Record<string, number> = {
   free_trial: 3,
@@ -548,7 +548,7 @@ function UsageBanner({ usage }: { usage: UsageState | null }) {
   );
 }
 
-/* â”€â”€ Floating widget â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Floating widget ─────────────────────────────────────────────── */
 
 const FLOATING_COLLAPSED_KEY = "lit.pulse_coach.floating.collapsed";
 
@@ -719,8 +719,8 @@ export function PulseCoachFloating() {
           {!t ? (
             <div className="font-body text-[11px] text-slate-400">
               {loading
-                ? "Reading your workspaceâ€¦"
-                : "All clear â€” nothing urgent on your plate today."}
+                ? "Reading your workspace…"
+                : "All clear — nothing urgent on your plate today."}
             </div>
           ) : (
             <NudgeCard
@@ -739,7 +739,7 @@ export function PulseCoachFloating() {
   );
 }
 
-/* â”€â”€ Tutorial card â€” page-aware onboarding â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Tutorial card — page-aware onboarding ───────────────────────── */
 function TutorialCard() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -803,7 +803,7 @@ function TutorialCard() {
           className="inline-flex h-4 items-center rounded px-1.5 text-[9px] font-bold uppercase tracking-[0.06em]"
           style={{ background: "rgba(0,240,255,0.15)", color: "#67E8F9", border: "1px solid rgba(0,240,255,0.3)" }}
         >
-          Tutorial Â· 30s
+          Tutorial · 30s
         </span>
         <button
           type="button"
@@ -841,54 +841,50 @@ function TutorialCard() {
   );
 }
 
-/* â”€â”€ Coach Composer â€” ask Pulse Coach anything â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-const PULSE_SEARCH_VIDEO_URL = "https://www.youtube-nocookie.com/embed/a9FhnCW89wY?rel=0";
-
+/* ── Coach Composer — ask Pulse Coach anything ───────────────────── */
 function CoachVideoGuide() {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="border-t border-white/5 px-3.5 py-3">
+    <section className="border-b border-slate-700/80 bg-slate-950/30 px-5 py-4">
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center gap-2 text-left"
+        className="flex w-full items-center justify-between gap-4 text-left"
         aria-expanded={expanded}
-        aria-controls="pulse-coach-video"
       >
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-cyan-400/30 bg-cyan-400/10 text-cyan-300">
-          <Video className="h-3.5 w-3.5" />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="font-display block text-[11.5px] font-semibold text-white">
-            Watch how search works
+        <span className="flex min-w-0 items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center border border-cyan-400/40 bg-cyan-400/10 text-cyan-300">
+            <Video className="h-4 w-4" aria-hidden="true" />
           </span>
-          <span className="font-body block text-[10.5px] text-slate-400">
-            Pulse Search and Company Search walkthrough
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold text-white">Watch how search works</span>
+            <span className="block text-xs text-slate-400">
+              Pulse Search and Company Search walkthrough
+            </span>
           </span>
         </span>
-        <ChevronRight
-          className={`h-3.5 w-3.5 text-slate-400 transition-transform ${expanded ? "rotate-90" : ""}`}
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+          aria-hidden="true"
         />
       </button>
 
       {expanded ? (
-        <div
-          id="pulse-coach-video"
-          className="mt-3 aspect-video w-full overflow-hidden rounded-md border border-white/10 bg-slate-950"
-        >
-          <iframe
-            className="h-full w-full"
-            src={PULSE_SEARCH_VIDEO_URL}
-            title="How to use Pulse Search and Company Search"
-            loading="lazy"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen
-          />
+        <div className="mt-4 overflow-hidden border border-slate-700 bg-black">
+          <div className="aspect-video w-full">
+            <iframe
+              className="h-full w-full"
+              src="https://www.youtube-nocookie.com/embed/a9FhnCW89wY?rel=0"
+              title="How to use LIT Pulse Search and Company Search"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+            />
+          </div>
         </div>
       ) : null}
-    </div>
+    </section>
   );
 }
 
@@ -960,7 +956,7 @@ function CoachComposer() {
           <div className="font-body text-[12px] leading-relaxed text-slate-200" style={{ whiteSpace: "pre-wrap" }}>
             {answer.md}
           </div>
-          {/* Inline search results â€” the Coach detected a data query
+          {/* Inline search results — the Coach detected a data query
               (geography / industry / lane / etc.) and ran it through
               the Pulse search pipeline. Each row navigates straight
               to the company profile. Hidden for meta / help answers. */}
@@ -985,7 +981,7 @@ function CoachComposer() {
                       </div>
                       {(loc || c.industry) ? (
                         <div className="font-body text-[10.5px] text-slate-400">
-                          {[loc, c.industry].filter(Boolean).join(" Â· ")}
+                          {[loc, c.industry].filter(Boolean).join(" · ")}
                         </div>
                       ) : null}
                     </button>
@@ -1032,14 +1028,14 @@ function CoachComposer() {
           className="rounded-md px-2.5 py-1.5 text-[11px] font-semibold text-white disabled:opacity-40"
           style={{ background: asking ? "rgba(0,240,255,0.1)" : "rgba(0,240,255,0.18)", border: "1px solid rgba(0,240,255,0.4)" }}
         >
-          {asking ? "â€¦" : "Ask"}
+          {asking ? "…" : "Ask"}
         </button>
       </form>
     </div>
   );
 }
 
-/* â”€â”€ Nudge card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Nudge card ──────────────────────────────────────────────────── */
 
 function NudgeCard({
   nudge,
@@ -1060,12 +1056,12 @@ function NudgeCard({
   // header ("PULSE COACH" in #00F0FF) so no dark/black font ever lands on
   // the slate gradient. The per-nudge accent is still used for the icon
   // chip + the dark-compact button background, but every text run is
-  // hardcoded bright via inline style â€” Tailwind purge / dark-mode
+  // hardcoded bright via inline style — Tailwind purge / dark-mode
   // overrides can't override these.
   const accent = nudge.accent || "#00F0FF";
   const TITLE_COLOR = "#FFFFFF";
   const BODY_COLOR = "#CBD5E1";   // slate-300
-  const CTA_COLOR = "#00F0FF";    // cyan â€” matches the PULSE COACH header
+  const CTA_COLOR = "#00F0FF";    // cyan — matches the PULSE COACH header
 
   if (variant === "dark-compact") {
     return (
@@ -1130,7 +1126,7 @@ function NudgeCard({
               color: "#7DD3FC",
             }}
           >
-            {nudge.lane_focus.from} â†’ {nudge.lane_focus.to}
+            {nudge.lane_focus.from} → {nudge.lane_focus.to}
           </span>
         )}
       </div>
@@ -1157,7 +1153,7 @@ function NudgeCard({
   );
 }
 
-/* â”€â”€ Re-export workspace lanes hook for the globe â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+/* ── Re-export workspace lanes hook for the globe ────────────────── */
 
 export function useWorkspaceLanes(): {
   lanes: WorkspaceLane[];
@@ -1166,4 +1162,3 @@ export function useWorkspaceLanes(): {
   const { result, loading } = usePulseCoach();
   return { lanes: result?.workspace_lanes || [], loading };
 }
-

--- a/frontend/src/features/coach/PulseCoachWidget.tsx
+++ b/frontend/src/features/coach/PulseCoachWidget.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   RefreshCw,
   Sparkles,
+  Video,
   X,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -41,13 +42,13 @@ import {
 } from "@/lib/onboardingState";
 
 /**
- * Pulse Coach widget — proactive AI nudges grounded in the user's
+ * Pulse Coach widget â€” proactive AI nudges grounded in the user's
  * workspace state. Two render modes share a single data source:
  *
- *   "floating"  — bottom-right pill that expands into a card. Mounted
+ *   "floating"  â€” bottom-right pill that expands into a card. Mounted
  *                 globally in AppShell so it follows the user across
  *                 every page.
- *   "inline"    — full hero panel rendered on the Dashboard.
+ *   "inline"    â€” full hero panel rendered on the Dashboard.
  *
  * The widget hits the `pulse-coach` edge function which returns LLM-
  * generated nudges + an aggregated workspace_lanes envelope used by
@@ -133,7 +134,7 @@ export function PulseCoachProvider({
   const { user } = useAuth();
   const userId = user?.id || null;
   // Initial render: read cache for the current user only. If the user
-  // is not yet known (auth still warming up) start empty — the userId
+  // is not yet known (auth still warming up) start empty â€” the userId
   // effect below kicks in once auth resolves.
   const [result, setResult] = useState<PulseCoachResult | null>(() => {
     if (typeof window === "undefined") return null;
@@ -166,15 +167,15 @@ export function PulseCoachProvider({
           // and the workspace-lanes list don't reflow on every coach
           // refresh:
           //
-          //   A. Zero-lane response while prev had lanes → keep prev.
+          //   A. Zero-lane response while prev had lanes â†’ keep prev.
           //      Prevents the globe blanking out if the LLM call drops
           //      the lanes block.
           //
-          //   B. Same lane keys as before → reuse the prev array
+          //   B. Same lane keys as before â†’ reuse the prev array
           //      reference. Without this, every refresh produced a new
           //      array (same content, new identity) which forced the
           //      `sorted` / `globeLanes` useMemos to recompute and the
-          //      GlobeCanvas three.js scene to rebuild — the visible
+          //      GlobeCanvas three.js scene to rebuild â€” the visible
           //      "tabs disappear and reflow" symptom on dashboard.
           setResult((prev) => {
             if (!r.ok) return r;
@@ -268,7 +269,7 @@ export function usePulseCoach(): PulseCoachContextValue {
   return ctx;
 }
 
-/* ── Action handler ──────────────────────────────────────────────── */
+/* â”€â”€ Action handler â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 function useNudgeActionHandler() {
   const navigate = useNavigate();
@@ -319,7 +320,7 @@ function useNudgeActionHandler() {
   );
 }
 
-/* ── Inline (dashboard hero) ─────────────────────────────────────── */
+/* â”€â”€ Inline (dashboard hero) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 export function PulseCoachInline() {
   const { result, loading, error, refresh, highlightLane, highlightedLane } =
@@ -389,15 +390,15 @@ export function PulseCoachInline() {
       {/* body */}
       {loading && nudges.length === 0 ? (
         <div className="font-body relative px-1 py-6 text-center text-[12px] text-slate-400">
-          Reading your workspace…
+          Reading your workspaceâ€¦
         </div>
       ) : error && nudges.length === 0 ? (
         <div className="font-body relative px-1 py-4 text-[12px] text-amber-300">
-          Coach is offline — {error}
+          Coach is offline â€” {error}
         </div>
       ) : nudges.length === 0 ? (
         <div className="font-body relative px-1 py-4 text-[12px] text-slate-400">
-          No nudges right now. Try saving a company or enriching a contact —
+          No nudges right now. Try saving a company or enriching a contact â€”
           Coach lights up once there's signal to work with.
         </div>
       ) : (
@@ -435,7 +436,7 @@ export function PulseCoachInline() {
   );
 }
 
-/* ── Plan + usage warning ───────────────────────────────────────── */
+/* â”€â”€ Plan + usage warning â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 const PLAN_PULSE_LIMITS: Record<string, number> = {
   free_trial: 3,
@@ -547,7 +548,7 @@ function UsageBanner({ usage }: { usage: UsageState | null }) {
   );
 }
 
-/* ── Floating widget ─────────────────────────────────────────────── */
+/* â”€â”€ Floating widget â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 const FLOATING_COLLAPSED_KEY = "lit.pulse_coach.floating.collapsed";
 
@@ -718,8 +719,8 @@ export function PulseCoachFloating() {
           {!t ? (
             <div className="font-body text-[11px] text-slate-400">
               {loading
-                ? "Reading your workspace…"
-                : "All clear — nothing urgent on your plate today."}
+                ? "Reading your workspaceâ€¦"
+                : "All clear â€” nothing urgent on your plate today."}
             </div>
           ) : (
             <NudgeCard
@@ -732,12 +733,13 @@ export function PulseCoachFloating() {
       ) : null}
 
       <TutorialCard />
+      <CoachVideoGuide />
       <CoachComposer />
     </div>
   );
 }
 
-/* ── Tutorial card — page-aware onboarding ───────────────────────── */
+/* â”€â”€ Tutorial card â€” page-aware onboarding â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 function TutorialCard() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -801,7 +803,7 @@ function TutorialCard() {
           className="inline-flex h-4 items-center rounded px-1.5 text-[9px] font-bold uppercase tracking-[0.06em]"
           style={{ background: "rgba(0,240,255,0.15)", color: "#67E8F9", border: "1px solid rgba(0,240,255,0.3)" }}
         >
-          Tutorial · 30s
+          Tutorial Â· 30s
         </span>
         <button
           type="button"
@@ -839,7 +841,57 @@ function TutorialCard() {
   );
 }
 
-/* ── Coach Composer — ask Pulse Coach anything ───────────────────── */
+/* â”€â”€ Coach Composer â€” ask Pulse Coach anything â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+const PULSE_SEARCH_VIDEO_URL = "https://www.youtube-nocookie.com/embed/a9FhnCW89wY?rel=0";
+
+function CoachVideoGuide() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border-t border-white/5 px-3.5 py-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 text-left"
+        aria-expanded={expanded}
+        aria-controls="pulse-coach-video"
+      >
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-cyan-400/30 bg-cyan-400/10 text-cyan-300">
+          <Video className="h-3.5 w-3.5" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="font-display block text-[11.5px] font-semibold text-white">
+            Watch how search works
+          </span>
+          <span className="font-body block text-[10.5px] text-slate-400">
+            Pulse Search and Company Search walkthrough
+          </span>
+        </span>
+        <ChevronRight
+          className={`h-3.5 w-3.5 text-slate-400 transition-transform ${expanded ? "rotate-90" : ""}`}
+        />
+      </button>
+
+      {expanded ? (
+        <div
+          id="pulse-coach-video"
+          className="mt-3 aspect-video w-full overflow-hidden rounded-md border border-white/10 bg-slate-950"
+        >
+          <iframe
+            className="h-full w-full"
+            src={PULSE_SEARCH_VIDEO_URL}
+            title="How to use Pulse Search and Company Search"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function CoachComposer() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -908,7 +960,7 @@ function CoachComposer() {
           <div className="font-body text-[12px] leading-relaxed text-slate-200" style={{ whiteSpace: "pre-wrap" }}>
             {answer.md}
           </div>
-          {/* Inline search results — the Coach detected a data query
+          {/* Inline search results â€” the Coach detected a data query
               (geography / industry / lane / etc.) and ran it through
               the Pulse search pipeline. Each row navigates straight
               to the company profile. Hidden for meta / help answers. */}
@@ -933,7 +985,7 @@ function CoachComposer() {
                       </div>
                       {(loc || c.industry) ? (
                         <div className="font-body text-[10.5px] text-slate-400">
-                          {[loc, c.industry].filter(Boolean).join(" · ")}
+                          {[loc, c.industry].filter(Boolean).join(" Â· ")}
                         </div>
                       ) : null}
                     </button>
@@ -980,14 +1032,14 @@ function CoachComposer() {
           className="rounded-md px-2.5 py-1.5 text-[11px] font-semibold text-white disabled:opacity-40"
           style={{ background: asking ? "rgba(0,240,255,0.1)" : "rgba(0,240,255,0.18)", border: "1px solid rgba(0,240,255,0.4)" }}
         >
-          {asking ? "…" : "Ask"}
+          {asking ? "â€¦" : "Ask"}
         </button>
       </form>
     </div>
   );
 }
 
-/* ── Nudge card ──────────────────────────────────────────────────── */
+/* â”€â”€ Nudge card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 function NudgeCard({
   nudge,
@@ -1008,12 +1060,12 @@ function NudgeCard({
   // header ("PULSE COACH" in #00F0FF) so no dark/black font ever lands on
   // the slate gradient. The per-nudge accent is still used for the icon
   // chip + the dark-compact button background, but every text run is
-  // hardcoded bright via inline style — Tailwind purge / dark-mode
+  // hardcoded bright via inline style â€” Tailwind purge / dark-mode
   // overrides can't override these.
   const accent = nudge.accent || "#00F0FF";
   const TITLE_COLOR = "#FFFFFF";
   const BODY_COLOR = "#CBD5E1";   // slate-300
-  const CTA_COLOR = "#00F0FF";    // cyan — matches the PULSE COACH header
+  const CTA_COLOR = "#00F0FF";    // cyan â€” matches the PULSE COACH header
 
   if (variant === "dark-compact") {
     return (
@@ -1078,7 +1130,7 @@ function NudgeCard({
               color: "#7DD3FC",
             }}
           >
-            {nudge.lane_focus.from} → {nudge.lane_focus.to}
+            {nudge.lane_focus.from} â†’ {nudge.lane_focus.to}
           </span>
         )}
       </div>
@@ -1105,7 +1157,7 @@ function NudgeCard({
   );
 }
 
-/* ── Re-export workspace lanes hook for the globe ────────────────── */
+/* â”€â”€ Re-export workspace lanes hook for the globe â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 export function useWorkspaceLanes(): {
   lanes: WorkspaceLane[];
@@ -1114,3 +1166,4 @@ export function useWorkspaceLanes(): {
   const { result, loading } = usePulseCoach();
   return { lanes: result?.workspace_lanes || [], loading };
 }
+

--- a/frontend/src/lib/email/templates/trialActivation.ts
+++ b/frontend/src/lib/email/templates/trialActivation.ts
@@ -1,4 +1,4 @@
-// Trial Day 2 Activation — behavior-gated. Skipped if user already has activity.
+// Trial Day 2 demo invitation. Skipped if the user already has activity.
 // event_type: 'trial_day_2_activation'
 
 import { renderEmailLayout } from "./baseLayout";
@@ -13,74 +13,47 @@ export interface TrialActivationContext {
   unsubscribeUrl: string;
 }
 
-function resolveName(firstName?: string): string {
-  return firstName && firstName.trim() ? firstName.trim() : "there";
-}
-
 export function buildTrialActivationEmail(ctx: TrialActivationContext): {
   subject: string;
   previewText: string;
   html: string;
   text: string;
 } {
-  const name = resolveName(ctx.firstName);
-  const appUrl = ctx.appUrl ?? "https://app.logisticintel.com";
-
-  const subject = "The fastest way to test LIT";
-  const previewText = "Try this simple workflow today.";
+  const name = ctx.firstName?.trim() || "there";
+  const subject = "Let us show you how to get the most from LIT";
+  const previewText = "Book a 30-minute walkthrough using your target accounts.";
+  const demoUrl = "https://cal.com/logisticintel/30min";
 
   const bodyHtml = `
 <p style="margin:0 0 16px 0;">Hi ${name},</p>
-<p style="margin:0 0 16px 0;">A lot of people sign up, poke around the dashboard, and then close the tab. That's a waste of a good trial.</p>
-<p style="margin:0 0 12px 0;">Here's the workflow that gets to value fastest:</p>
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;width:100%;margin:0 0 20px 0;">
-  <tr>
-    <td style="padding:12px 16px;background-color:#F1F5F9;border-radius:8px 8px 0 0;border-bottom:1px solid #E2E8F0;font-size:15px;color:#0F172A;line-height:1.5;">
-      <strong style="display:inline-block;width:24px;text-align:center;background-color:#2563EB;color:#fff;border-radius:50%;font-size:12px;height:22px;line-height:22px;margin-right:8px;">1</strong>
-      Go to <strong>Pulse</strong> and search your best lane (e.g., "Mexico cross-border" or "USEC to Europe").
-    </td>
-  </tr>
-  <tr>
-    <td style="padding:12px 16px;background-color:#F8FAFC;border-bottom:1px solid #E2E8F0;font-size:15px;color:#0F172A;line-height:1.5;">
-      <strong style="display:inline-block;width:24px;text-align:center;background-color:#2563EB;color:#fff;border-radius:50%;font-size:12px;height:22px;line-height:22px;margin-right:8px;">2</strong>
-      Open three companies that look active — check shipment cadence and carrier mix.
-    </td>
-  </tr>
-  <tr>
-    <td style="padding:12px 16px;background-color:#F1F5F9;border-bottom:1px solid #E2E8F0;font-size:15px;color:#0F172A;line-height:1.5;">
-      <strong style="display:inline-block;width:24px;text-align:center;background-color:#2563EB;color:#fff;border-radius:50%;font-size:12px;height:22px;line-height:22px;margin-right:8px;">3</strong>
-      Save the one or two that look like real opportunities. Run a Pulse AI brief.
-    </td>
-  </tr>
-  <tr>
-    <td style="padding:12px 16px;background-color:#F8FAFC;border-radius:0 0 8px 8px;font-size:15px;color:#0F172A;line-height:1.5;">
-      <strong style="display:inline-block;width:24px;text-align:center;background-color:#2563EB;color:#fff;border-radius:50%;font-size:12px;height:22px;line-height:22px;margin-right:8px;">4</strong>
-      Use the brief to write your first outreach — or pull contacts directly from LIT.
-    </td>
-  </tr>
-</table>
-<p style="margin:0 0 16px 0;">That's it. Four steps, under 15 minutes. Most sales reps come away with at least one new prospect worth a real conversation.</p>`;
+<p style="margin:0 0 16px 0;">The fastest way to turn your trial into a real prospecting workflow is to see LIT using the accounts and lanes your team already works.</p>
+<p style="margin:0 0 12px 0;font-weight:600;">In a focused 30-minute demo, we'll show you how to:</p>
+<ul style="margin:0 0 18px 0;padding-left:22px;line-height:1.7;">
+  <li>Find active shippers in your target market.</li>
+  <li>Read shipment cadence, lanes, carriers, and buying signals.</li>
+  <li>Identify and enrich the right decision-makers.</li>
+  <li>Turn the intelligence into a campaign-ready prospect list.</li>
+</ul>
+<p style="margin:0 0 16px 0;">Bring two or three target companies and we'll walk through them together. No generic sales presentation.</p>
+<p style="margin:0;color:#475569;font-size:14px;">Choose a time that works for you and leave with a repeatable LIT workflow.</p>`;
 
   const bodyText = `Hi ${name},
 
-A lot of people sign up, poke around the dashboard, and then close the tab. That's a waste of a good trial.
+The fastest way to turn your trial into a real prospecting workflow is to see LIT using the accounts and lanes your team already works.
 
-Here's the workflow that gets to value fastest:
+In a focused 30-minute demo, we'll show you how to find active shippers, read buying signals, identify decision-makers, and build a campaign-ready prospect list.
 
-1. Go to Pulse and search your best lane (e.g., "Mexico cross-border" or "USEC to Europe").
-2. Open three companies that look active — check shipment cadence and carrier mix.
-3. Save the one or two that look like real opportunities. Run a Pulse AI brief.
-4. Use the brief to write your first outreach — or pull contacts directly from LIT.
+Bring two or three target companies and we'll walk through them together. No generic sales presentation.
 
-That's it. Four steps, under 15 minutes. Most sales reps come away with at least one new prospect worth a real conversation.`;
+Book your demo: ${demoUrl}`;
 
   const { html, text } = renderEmailLayout({
-    headline: "Test LIT in 10 minutes.",
-    subtitle: "The workflow that gets to value fastest.",
+    headline: "See LIT work on your accounts.",
+    subtitle: "A focused 30-minute walkthrough with your target market.",
     bodyHtml,
     bodyText,
-    ctaText: "Open your dashboard",
-    ctaUrl: `${appUrl}/dashboard`,
+    ctaText: "Book your 30-minute demo",
+    ctaUrl: demoUrl,
     unsubscribeUrl: ctx.unsubscribeUrl,
     previewText,
   });

--- a/marketing/app/api/cron/lead-sequence-dispatch/route.ts
+++ b/marketing/app/api/cron/lead-sequence-dispatch/route.ts
@@ -88,8 +88,9 @@ function checkAuth(req: NextRequest): Response | null {
     });
   }
   const auth = req.headers.get("authorization");
-  const vercelCron = req.headers.get("x-vercel-cron");
-  if (auth !== `Bearer ${expected}` || !vercelCron) {
+  // Vercel Cron authenticates with CRON_SECRET in Authorization. It does
+  // not guarantee a separate x-vercel-cron header.
+  if (auth !== `Bearer ${expected}`) {
     return new Response(JSON.stringify({ error: "unauthorized" }), {
       status: 401,
       headers: { "content-type": "application/json" },

--- a/marketing/app/api/cron/reengagement-enroll/route.ts
+++ b/marketing/app/api/cron/reengagement-enroll/route.ts
@@ -25,7 +25,7 @@ export const maxDuration = 60;
  *   1. lit_leads row exists with created_at older than 30 days.
  *   2. No row in lit_lead_sequence_queue with sequence_key='re-engagement'
  *      for this email (never enrolled before — re-engagement is once-only).
- *   3. No 'opened' event in lit_resend_events for this email in the last
+ *   3. No 'opened' event in lit_email_events for this email in the last
  *      30 days. (Open = active = leave them alone.)
  *   4. Not bounced or complained per lit_email_suppression_status RPC.
  *   5. Not globally unsubscribed per lit_email_preferences.unsubscribed_all.
@@ -96,13 +96,15 @@ export async function GET(req: NextRequest) {
 
   // 3. Exclude anyone with an opened event in the last 30d (active).
   const { data: recentOpens } = await supa
-    .from("lit_resend_events")
-    .select("email_to")
+    .from("lit_email_events")
+    .select("metadata_json")
     .eq("event_type", "opened")
     .gt("created_at", cutoffIso)
-    .in("email_to", uniqueEmails);
+    .filter("metadata_json->>email_to", "in", `(${uniqueEmails.join(",")})`);
   const openedSet = new Set(
-    (recentOpens ?? []).map((r: { email_to: string }) => (r.email_to || "").toLowerCase()),
+    (recentOpens ?? []).map((r: { metadata_json?: { email_to?: string } }) =>
+      (r.metadata_json?.email_to || "").toLowerCase(),
+    ),
   );
 
   // 4. Exclude leads with global unsubscribe preference.
@@ -181,7 +183,10 @@ export async function GET(req: NextRequest) {
 
     const { error: insErr } = await supa
       .from("lit_lead_sequence_queue")
-      .insert(queueRows);
+      .upsert(queueRows, {
+        onConflict: "lead_id,sequence_key,step",
+        ignoreDuplicates: true,
+      });
 
     if (insErr) {
       console.error(

--- a/marketing/vercel.json
+++ b/marketing/vercel.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "/api/cron/lead-sequence-dispatch",
-      "schedule": "*/30 * * * *"
+      "schedule": "0 15 * * *"
     },
     {
       "path": "/api/cron/reengagement-enroll",

--- a/marketing/vercel.json
+++ b/marketing/vercel.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "/api/cron/lead-sequence-dispatch",
-      "schedule": "0 15 * * *"
+      "schedule": "*/30 * * * *"
     },
     {
       "path": "/api/cron/reengagement-enroll",


### PR DESCRIPTION
## Summary
- add an expandable Pulse Search and Company Search YouTube guide to Pulse Coach
- change the behavior-gated Day 2 trial email to a 30-minute demo invitation
- fix Vercel Cron authentication for the lead-sequence dispatcher
- align re-engagement opens with the live email event table and make enrollment duplicate-safe
- run the lead dispatcher every 30 minutes

## Operations completed
- cancelled 87 overdue legacy queue rows
- cancelled 10 future-dated legacy queue rows
- removed the duplicate post-signup demo trigger
- secured lifecycle edge-function invocation with the internal cron header
- aligned bounce/complaint suppression with live Resend event storage

## Verification
- branch diff is limited to five intended files
- legacy unsent queue is empty before enabling the repaired dispatcher