### PR TITLE
Fix Pulse Coach video toggle crash

### DIFF
--- a/frontend/src/features/coach/PulseCoachWidget.tsx
+++ b/frontend/src/features/coach/PulseCoachWidget.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import {
   ArrowRight,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   RefreshCw,


### PR DESCRIPTION
Imports the ChevronDown icon used by the expandable Pulse Coach video guide. This fixes the production `ChevronDown is not defined` runtime error.