### PR TITLE
Fix video SEO and rebuild pricing authority pages

### DIFF
--- a/marketing/app/_bofu/data.tsx
+++ b/marketing/app/_bofu/data.tsx
@@ -757,12 +757,12 @@ export const BOFU_PAGES: BofuPage[] = [
       {
         question: "Can my whole team use it?",
         answer:
-          "Yes — shared watchlists, territories, and a built-in Command Center CRM, plus native push to HubSpot, Salesforce, Outreach, Apollo, Salesloft, and SmartLead on team plans. Searching is free for every seat.",
+          "Yes. Team plans include shared account workflows, Command Center CRM, and connected Gmail or Microsoft Outlook sending. Other integrations are listed as planned until they are released. The 7-day trial includes 10 searches and 10 verified contacts; searching is not presented as free forever.",
       },
       {
         question: "How do I evaluate it against our current stack?",
         answer:
-          "Run your live pipeline through it: search ten current opportunities, unlock the accounts, and compare LIT's shipment evidence and contacts against what your stack shows. The free trial's 10 unlocks and 10 enrichments exist exactly for that test.",
+          "Run your live pipeline through it: search ten current opportunities and compare LIT's shipment evidence and contacts against what your stack shows. The 7-day trial's 10 searches and 10 verified contacts exist exactly for that test.",
       },
     ],
     relatedHeading: "Explore the intelligence layers.",

--- a/marketing/app/best/_data.ts
+++ b/marketing/app/best/_data.ts
@@ -299,7 +299,7 @@ export const BEST_LIST_PAGES: BestListPage[] = [
     methodology:
       "Ranked on coverage, freshness, action layer, and per-seat economics for a 5-rep team.",
     entries: [
-      { rank: 1, name: "LIT", pitch: "US-deep, action-layered, per-seat priced.", whenToPick: "Revenue teams." },
+      { rank: 1, name: "LIT", pitch: "US-deep, action-layered, per-seat priced.", whenToPick: "Freight sales teams." },
       { rank: 2, name: "Panjiva", pitch: "Global, deep, analyst-grade.", whenToPick: "Enterprise research.", vsSlug: "panjiva" },
       { rank: 3, name: "Datamyne", pitch: "Enterprise global trade.", whenToPick: "Enterprise compliance.", vsSlug: "datamyne" },
       { rank: 4, name: "ImportGenius", pitch: "US historical depth.", whenToPick: "Long-tail research.", vsSlug: "importgenius" },

--- a/marketing/app/bill-of-lading-database/page.tsx
+++ b/marketing/app/bill-of-lading-database/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { SearchDemandPage, type SearchDemandPageData } from "@/components/sections/SearchDemandPage";
+import { buildMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Bill of Lading Database for Freight Sales Teams",
+  description: "Search bill of lading data by importer, supplier, lane, port, carrier, and product, then connect shipment evidence to freight sales accounts and contacts.",
+  path: "/bill-of-lading-database",
+  eyebrow: "Bill of lading database",
+});
+
+const page: SearchDemandPageData = {
+  slug: "bill-of-lading-database",
+  eyebrow: "Bill of lading database",
+  title: "Search shipment records, then turn the evidence into a freight sales account.",
+  intro: "Logistics Intel organizes U.S. customs bill of lading records around the questions freight sales teams ask: who is shipping, what they move, which lanes they use, how often they move, and who to contact next.",
+  definition: "A bill of lading database is a searchable collection of shipment records that identifies parties, products, ports, carriers, dates, and routing details associated with cargo movements. For freight sales, the useful version does more than return rows. It resolves duplicate names into company profiles, summarizes shipment patterns, and connects those patterns to account research and outreach.",
+  capabilities: [
+    { title: "Search beyond company names", body: "Filter shipment activity by importer, supplier, product description, HS code, origin, destination, port, carrier, and date instead of relying on one exact company spelling." },
+    { title: "Resolve records into accounts", body: "Group related filings and company-name variations into a usable account view with recent activity, top lanes, carrier mix, volume patterns, and shipment cadence." },
+    { title: "Move from research to action", body: "Save the company, find relevant logistics and supply-chain contacts, create a Pulse AI account brief, and continue the work inside Command Center." },
+  ],
+  workflow: [
+    { title: "Define the freight pattern", body: "Start with the lane, product, port, carrier, geography, or shipper profile your team can serve well." },
+    { title: "Verify current activity", body: "Review recent shipment records, cadence, counterparties, and lane concentration before deciding an account belongs in the pipeline." },
+    { title: "Prepare the sales motion", body: "Identify the right contact, save the account, document the freight angle, and build outreach around observable shipment activity." },
+  ],
+  faqs: [
+    { question: "What information appears in a bill of lading database?", answer: "Common fields include shipper, consignee, notify party, carrier, vessel, origin and destination ports, product description, shipment date, weight, quantity, and container information. Field availability varies by filing and source." },
+    { question: "Can I search bill of lading records by product?", answer: "Yes. Logistics Intel supports product-description and HS-code research alongside company, port, carrier, lane, and geography filters, allowing a sales team to define a market by what is moving rather than by a purchased company list." },
+    { question: "How does bill of lading data help a freight forwarder?", answer: "It provides evidence that a company ships, shows the lanes and products involved, reveals cadence and carrier patterns, and gives a rep a factual reason to prioritize the account and tailor the first conversation." },
+    { question: "Is a bill of lading database the same as a contact database?", answer: "No. Shipment records describe freight activity; contact data identifies people. Logistics Intel connects the two workflows so a rep can research the shipment pattern and then find relevant logistics, supply-chain, import, procurement, or transportation contacts where available." },
+  ],
+  related: [
+    { href: "/trade-intelligence", label: "Trade intelligence", body: "Explore how shipment records become lane, port, carrier, and company-level intelligence." },
+    { href: "/importer-leads", label: "Importer leads", body: "Build prospect lists from companies with observable U.S. import activity." },
+    { href: "/company-intelligence", label: "Company intelligence", body: "See how Pulse Explorer organizes freight accounts on an interactive map." },
+  ],
+};
+
+export default function BillOfLadingDatabasePage() {
+  return <SearchDemandPage page={page} />;
+}

--- a/marketing/app/careers/page.tsx
+++ b/marketing/app/careers/page.tsx
@@ -63,7 +63,7 @@ export default function CareersPage() {
         eyebrow="Careers"
         title="Build the platform"
         titleHighlight="freight sales actually wants."
-        subtitle="LIT is a small, operator-grade team building the revenue intelligence layer for global trade. Remote-first, async-default, ship-bias on."
+        subtitle="LIT is a small, operator-grade team building freight sales intelligence software for global trade. Remote-first, async-default, ship-bias on."
       />
 
       <Section top="md" bottom="md">

--- a/marketing/app/company-intelligence/page.tsx
+++ b/marketing/app/company-intelligence/page.tsx
@@ -21,6 +21,9 @@ const DIRECT_DEMO_URL = "https://cal.com/logisticintel/15min";
 const PLAYBOOK_URL = "/freight-leads";
 const VIDEO_URL = "https://www.youtube.com/watch?v=a9FhnCW89wY";
 const VIDEO_THUMBNAIL_URL = "https://i.ytimg.com/vi/a9FhnCW89wY/maxresdefault.jpg";
+// The tutorial was published with the first video SEO release on June 30, 2026.
+// Google requires uploadDate for VideoObject rich-result eligibility.
+const VIDEO_UPLOAD_DATE = "2026-06-30T13:32:51-04:00";
 
 const LEARNING_BULLETS = [
   "Search active shippers by company name, region, city, state, or ZIP code",
@@ -107,6 +110,7 @@ const VIDEO_OBJECT_JSONLD = {
   description:
     "See how Logistics Intel helps freight teams search active shippers, analyze trade lanes, enrich contacts, save views, and generate freight intelligence reports from one workspace.",
   thumbnailUrl: [VIDEO_THUMBNAIL_URL],
+  uploadDate: VIDEO_UPLOAD_DATE,
   embedUrl: "https://www.youtube.com/embed/a9FhnCW89wY",
   contentUrl: VIDEO_URL,
   publisher: {

--- a/marketing/app/freight-forwarder-crm/page.tsx
+++ b/marketing/app/freight-forwarder-crm/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { SearchDemandPage, type SearchDemandPageData } from "@/components/sections/SearchDemandPage";
+import { buildMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Freight Forwarder CRM with Shipment Intelligence",
+  description: "Manage freight sales accounts with shipment history, trade lanes, contacts, account briefs, tasks, outreach context, and pipeline stages in one workspace.",
+  path: "/freight-forwarder-crm",
+  eyebrow: "Freight forwarder CRM",
+});
+
+const page: SearchDemandPageData = {
+  slug: "freight-forwarder-crm",
+  eyebrow: "Freight forwarder CRM",
+  title: "A freight sales CRM that already understands the account's shipment activity.",
+  intro: "Command Center connects account ownership, contacts, tasks, outreach, and pipeline stages to the shipment and trade-lane context that freight forwarder sales teams use to qualify opportunities.",
+  definition: "A freight forwarder CRM should manage more than names, notes, and deal stages. It should keep the account's shipment activity, lanes, products, contacts, research, follow-ups, and sales history together so the next action is based on freight context rather than an empty record created after the research is finished.",
+  capabilities: [
+    { title: "Account context from the beginning", body: "Start with company and shipment intelligence, then save the account with its lane, volume, carrier, supplier, and opportunity context attached." },
+    { title: "Contacts tied to the shipper", body: "Organize relevant logistics, transportation, supply-chain, procurement, and import contacts alongside the company record and the reason the account was selected." },
+    { title: "Pipeline without losing the research", body: "Move accounts through stages, assign next actions, preserve notes, and review activity without separating CRM hygiene from the trade data that created the opportunity." },
+  ],
+  workflow: [
+    { title: "Find and qualify", body: "Search active shippers and review shipment cadence, lane fit, carrier patterns, and account-level opportunity signals." },
+    { title: "Save and assign", body: "Add the account to Command Center, associate the right contacts, assign ownership, and document the freight angle." },
+    { title: "Work the opportunity", body: "Track follow-ups, connected-mailbox outreach, notes, tasks, and pipeline movement while keeping the original freight evidence visible." },
+  ],
+  faqs: [
+    { question: "What makes a CRM freight-forwarder specific?", answer: "It keeps shipment activity, trade lanes, shipper qualification, logistics contacts, account ownership, outreach, and pipeline stages together. A generic CRM can store a company; a freight-specific workflow helps explain why the company is worth pursuing now." },
+    { question: "Does Logistics Intel replace every enterprise CRM?", answer: "Not necessarily. Command Center is designed to give freight sales teams a focused prospecting and account-workflow layer. Large organizations may keep a broader system of record and use planned or custom integrations as they become available." },
+    { question: "Can teams send email from the platform?", answer: "Connected Gmail and Microsoft Outlook mailbox sending are available. Other connectors are described as planned on the integrations page until they are released." },
+    { question: "Does the 7-day trial include the full paid-plan capacity?", answer: "No. The trial includes 10 searches and 10 verified contacts with no credit card required. Paid-plan quotas, seats, and support levels are shown transparently on the pricing page." },
+  ],
+  related: [
+    { href: "/command-center", label: "Command Center", body: "Explore the account, contact, task, and pipeline workspace inside Logistics Intel." },
+    { href: "/outbound-engine", label: "Freight outreach", body: "See how connected Gmail and Outlook sending fits into the prospecting workflow." },
+    { href: "/pricing", label: "Plans and pricing", body: "Compare seats, research capacity, contact reveals, support, and governance." },
+  ],
+};
+
+export default function FreightForwarderCrmPage() {
+  return <SearchDemandPage page={page} />;
+}

--- a/marketing/app/layout.tsx
+++ b/marketing/app/layout.tsx
@@ -79,7 +79,7 @@ export const metadata: Metadata = {
     url: SITE_URL,
     title: "Logistics Intel — Freight Prospecting Software for Logistics Sales Teams",
     description:
-      "Find active shippers, logistics contacts, shipment activity, trade lanes, and freight sales signals in one revenue intelligence platform.",
+      "Find active shippers, logistics contacts, shipment activity, trade lanes, and freight sales signals in one freight sales intelligence platform.",
     images: [
       { url: "/api/og", width: 1200, height: 630, alt: "Logistics Intel" },
     ],
@@ -147,7 +147,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               "@type": "Organization",
               "@id": `${SITE_URL}/#organization`,
               name: "Logistics Intel",
+              legalName: "Logistics Intel, Inc.",
               alternateName: "LIT",
+              description:
+                "Freight prospecting and sales intelligence software for freight forwarders, freight brokers, 3PLs, NVOCCs, customs brokers, and logistics sales teams.",
               url: SITE_URL,
               logo: `${SITE_URL}/icon-512.png`,
               sameAs: [
@@ -159,7 +162,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 {
                   "@type": "ContactPoint",
                   contactType: "sales",
-                  email: "support@logisticintel.com",
+                  email: "sales@logisticintel.com",
                   availableLanguage: ["English"],
                 },
               ],

--- a/marketing/app/page.tsx
+++ b/marketing/app/page.tsx
@@ -406,7 +406,7 @@ function ProblemSection() {
       <div className="mx-auto max-w-container">
         <div className="mx-auto max-w-[780px] text-center">
           <div className="eyebrow">The problem</div>
-          <h2 className="display-lg mt-3">Revenue teams are flying blind in a data-rich world.</h2>
+          <h2 className="display-lg mt-3">Freight sales teams are flying blind in a data-rich world.</h2>
           <p className="lead mx-auto mt-3 max-w-[640px]">
             Every go-to-market stack has holes. LIT closes them — from first signal to closed deal.
           </p>

--- a/marketing/app/press/page.tsx
+++ b/marketing/app/press/page.tsx
@@ -31,7 +31,7 @@ const FACTS: { label: string; value: string; sub?: string }[] = [
   {
     label: "Founded",
     value: "2024",
-    sub: "Operator-grade revenue intelligence for global trade.",
+    sub: "Operator-grade freight sales intelligence for global trade.",
   },
   {
     label: "Headquarters",
@@ -281,7 +281,7 @@ export default function PressPage() {
         eyebrow="Press & media"
         title="Press kit, brand assets, and"
         titleHighlight="recent coverage."
-        subtitle="Writing about freight tech, trade data, or revenue intelligence? We're happy to help with quotes, demos, screenshots, and background — usually within one business day."
+        subtitle="Writing about freight technology, trade data, or freight sales software? We're happy to help with quotes, demos, screenshots, and background — usually within one business day."
         primaryCta={{
           label: "Contact press",
           href: "mailto:press@logisticintel.com",
@@ -323,7 +323,7 @@ export default function PressPage() {
           </h2>
           <div className="font-body mt-6 space-y-5 text-[17px] leading-[1.7] text-ink-700">
             <p>
-              Logistics Intel is a revenue intelligence platform built for global trade.
+              Logistics Intel is a freight prospecting and sales intelligence platform built for global trade.
               We combine shipment data, company intelligence, and CRM workflows into one
               system so freight brokers, forwarders, 3PLs, and NVOCCs can find the right
               accounts, reach the right people, and run outbound on real signal — not
@@ -332,7 +332,7 @@ export default function PressPage() {
             <p>
               The product pairs a customs and trade-flow dataset with Pulse Coach, an
               AI layer that watches accounts and surfaces what changed and what to do
-              about it. Revenue teams use LIT to move from signal to action without
+              about it. Freight sales teams use LIT to move from signal to action without
               leaving the page.
             </p>
           </div>

--- a/marketing/app/pricing/PricingComparison.tsx
+++ b/marketing/app/pricing/PricingComparison.tsx
@@ -56,11 +56,12 @@ const GROUPS: Group[] = [
   {
     category: "Integrations",
     rows: [
-      { label: "HubSpot sync", starter: false, growth: true, scale: true, enterprise: true },
-      { label: "Salesforce sync", starter: false, growth: true, scale: true, enterprise: true },
-      { label: "Snowflake / warehouse sync", starter: false, growth: false, scale: false, enterprise: true },
-      { label: "API access", starter: false, growth: true, scale: true, enterprise: true },
-      { label: "Custom integrations", starter: false, growth: false, scale: false, enterprise: true },
+      { label: "Gmail connected-mailbox sending", starter: true, growth: true, scale: true, enterprise: true },
+      { label: "Microsoft Outlook connected-mailbox sending", starter: true, growth: true, scale: true, enterprise: true },
+      { label: "HubSpot connector", starter: "Planned", growth: "Planned", scale: "Planned", enterprise: "Custom" },
+      { label: "Salesforce connector", starter: "Planned", growth: "Planned", scale: "Planned", enterprise: "Custom" },
+      { label: "Data warehouse synchronization", starter: false, growth: false, scale: false, enterprise: "Custom" },
+      { label: "Custom integrations", starter: false, growth: false, scale: false, enterprise: "Available" },
     ],
   },
   {
@@ -107,7 +108,11 @@ export function PricingComparison() {
       <div className="mx-auto max-w-container">
         <div className="mx-auto max-w-[680px] text-center">
           <div className="eyebrow">Compare plans</div>
-          <h2 className="display-lg mt-3">Every capability, side by side.</h2>
+          <h2 className="display-lg mt-3">Compare the details when you need them.</h2>
+          <p className="font-body mt-4 text-[15px] leading-relaxed text-ink-500">
+            Start with team fit above. Use this table only to confirm quotas, governance,
+            and support requirements before you choose.
+          </p>
         </div>
 
         <div className="mt-10 overflow-x-auto rounded-3xl border border-ink-100 bg-white shadow-sm">

--- a/marketing/app/pricing/PricingTiers.tsx
+++ b/marketing/app/pricing/PricingTiers.tsx
@@ -1,45 +1,22 @@
 "use client";
 
 import { useState } from "react";
-import { Check } from "lucide-react";
+import { ArrowRight, Check, ChevronDown, ShieldCheck, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { APP_SIGNUP_URL } from "@/lib/app-urls";
 
-/**
- * Plan-card grid with a monthly / annual billing toggle. Single toggle
- * controls all four cards.
- *
- * Pricing and limits sourced from the Supabase `plans` table (rows where
- * `is_active = true`). Annual values are stored as a yearly total
- * (`price_yearly`) and rendered here as the equivalent per-seat per-month
- * cost (yearly / 12, rounded). When plan rows change, re-sync by
- * re-running the same SELECT against `plans` and updating
- * PRICE_SOURCE_LAST_SYNC below. Stripe remains the source of truth at
- * checkout — these numbers exist as the marketing anchor and must match
- * the Stripe products linked by `stripe_price_id_monthly` /
- * `stripe_price_id_yearly`.
- *
- * Feature copy reflects the real per-tier integer limits from the
- * `plans` table — never claim "unlimited" for a tier that has finite
- * caps. Only the Enterprise row has all-null limits, so only Enterprise
- * may surface unlimited usage.
- */
-
-// Pricing + limits sourced from Supabase plans table on 2026-05-31.
-// When plan rows change, re-sync via the same SELECT and update
-// PRICE_SOURCE_LAST_SYNC.
 const PRICE_SOURCE_LAST_SYNC = "2026-05-31";
 
 type Tier = {
   id: "starter" | "growth" | "scale" | "enterprise";
   name: string;
-  tagline: string;
-  /* Monthly price in USD per workspace. `null` => contact-sales. */
+  bestFor: string;
+  outcome: string;
   monthly: number | null;
-  /* Annual price billed monthly equivalent (per workspace). `null` => contact-sales. */
   annual: number | null;
-  rhythm: string; // "/ month" or empty
-  features: string[];
+  annualTotal: number | null;
+  highlights: string[];
+  details: string[];
   cta: { label: string; href: string };
   highlight?: boolean;
 };
@@ -48,259 +25,120 @@ const TIERS: Tier[] = [
   {
     id: "starter",
     name: "Starter",
-    tagline: "For solo freight prospectors getting their first 50 conversations on the books.",
-    // Supabase plans.code = "starter": price_monthly $125.00, price_yearly $1125.00
-    // Annual per-month equivalent: 1125 / 12 = $93.75 ≈ $94
+    bestFor: "One freight salesperson",
+    outcome: "Build a focused book of active shipper accounts without buying another static list.",
     monthly: 125,
     annual: 94,
-    rhythm: "/ month",
-    features: [
-      "75 customs shipment searches / mo",
-      "50 saved companies",
-      "25 Pulse AI account briefs / mo",
-      "10 CSV exports / mo",
-      "250 campaign email sends / mo",
-      "75 LinkedIn touches / mo",
-      "1 user seat",
-      "Email support",
-    ],
-    cta: { label: "Start free trial", href: APP_SIGNUP_URL },
+    annualTotal: 1125,
+    highlights: ["75 shipment searches each month", "50 saved shipper accounts", "25 Pulse AI account briefs", "1 user seat"],
+    details: ["10 CSV exports each month", "250 connected-mailbox sends each month", "75 LinkedIn activity touches each month", "Lane and shipper alerts", "Email support"],
+    cta: { label: "Start 7-day trial", href: APP_SIGNUP_URL },
   },
   {
     id: "growth",
     name: "Growth",
-    tagline: "For freight sales teams running multi-channel outbound across a real book of accounts.",
-    // Supabase plans.code = "growth": price_monthly $499.00, price_yearly $4491.00
-    // Annual per-month equivalent: 4491 / 12 = $374.25 ≈ $374
+    bestFor: "Freight sales teams",
+    outcome: "Turn shipment signals into coordinated account research, outreach, and pipeline.",
     monthly: 499,
     annual: 374,
-    rhythm: "/ month",
-    features: [
-      "Everything in Starter",
-      "350 customs shipment searches / mo",
-      "150 verified contact reveals / mo",
-      "100 Pulse AI account briefs / mo",
-      "250 saved contacts",
-      "1,000 campaign email sends / mo",
-      "250 LinkedIn touches / mo",
-      "HubSpot / Salesforce sync",
-      "3 user seats included",
-      "Priority support",
-    ],
-    cta: { label: "Start free trial", href: APP_SIGNUP_URL },
+    annualTotal: 4491,
+    highlights: ["350 shipment searches each month", "150 verified contact reveals", "100 Pulse AI account briefs", "3 user seats included"],
+    details: ["250 saved contacts", "1,000 connected-mailbox sends each month", "250 LinkedIn activity touches each month", "Command Center CRM and pipeline stages", "Gmail and Outlook mailbox sending", "Priority support"],
+    cta: { label: "Start 7-day trial", href: APP_SIGNUP_URL },
     highlight: true,
   },
   {
     id: "scale",
     name: "Scale",
-    tagline: "For multi-seat ops teams running outbound at high volume across every lane.",
-    // Supabase plans.code = "scale": price_monthly $999.00, price_yearly $8991.00
-    // Annual per-month equivalent: 8991 / 12 = $749.25 ≈ $749
+    bestFor: "Established multi-seat teams",
+    outcome: "Give a larger sales organization more research capacity, contacts, and managed support.",
     monthly: 999,
     annual: 749,
-    rhythm: "/ month",
-    features: [
-      "Everything in Growth",
-      "1,000 customs shipment searches / mo",
-      "500 verified contact reveals / mo",
-      "500 Pulse AI account briefs / mo",
-      "1,000 saved contacts",
-      "2,500 campaign email sends / mo",
-      "750 LinkedIn touches / mo",
-      "100 CSV exports / mo",
-      "5 user seats included",
-      "SLA-backed support",
-    ],
-    cta: { label: "Start free trial", href: APP_SIGNUP_URL },
+    annualTotal: 8991,
+    highlights: ["1,000 shipment searches each month", "500 verified contact reveals", "500 Pulse AI account briefs", "5 user seats included"],
+    details: ["1,000 saved contacts", "2,500 connected-mailbox sends each month", "750 LinkedIn activity touches each month", "100 CSV exports each month", "Command Center CRM and pipeline forecasting", "SLA-backed support"],
+    cta: { label: "Start 7-day trial", href: APP_SIGNUP_URL },
   },
   {
     id: "enterprise",
     name: "Enterprise",
-    tagline: "For multi-org programs and large freight networks with custom data and security needs.",
-    // Supabase plans.code = "enterprise": price_monthly null, price_yearly null
-    // All usage limits null = unlimited. seat_limit = 10 (custom beyond).
-    // market_benchmark_enabled = true (Enterprise-only).
+    bestFor: "Large or multi-organization programs",
+    outcome: "Configure governance, data access, integrations, and service levels around your operation.",
     monthly: null,
     annual: null,
-    rhythm: "",
-    features: [
-      "Everything in Scale",
-      "Unlimited shipment searches",
-      "Unlimited contact reveals",
-      "Unlimited Pulse AI briefs",
-      "Market benchmark analytics",
-      "SSO + SCIM provisioning",
-      "Snowflake / data warehouse sync",
-      "Custom data feeds and integrations",
-      "Custom seat count (10+ included)",
-      "Named TAM and custom SLAs",
-    ],
-    cta: { label: "Contact sales", href: "/demo" },
+    annualTotal: null,
+    highlights: ["Custom usage and seat allocation", "SSO and SCIM provisioning", "Custom data feeds and integrations", "Named technical account manager"],
+    details: ["Market benchmark analytics", "Data warehouse synchronization", "Custom security review and procurement support", "Audit logs and access controls", "Custom service-level agreement"],
+    cta: { label: "Design your plan", href: "/demo" },
   },
+];
+
+const TRIAL_POINTS = [
+  { icon: ShieldCheck, title: "No credit card", body: "Evaluate the real workflow first" },
+  { icon: Sparkles, title: "10 + 10 included", body: "10 searches and 10 verified contacts" },
+  { icon: ArrowRight, title: "Cancel without friction", body: "Monthly plans end at the billing period" },
 ];
 
 export function PricingTiers() {
   const [billing, setBilling] = useState<"monthly" | "annual">("annual");
 
   return (
-    <section className="px-5 sm:px-8 py-16" data-price-source-last-sync={PRICE_SOURCE_LAST_SYNC}>
+    <section className="px-5 py-16 sm:px-8 sm:py-20" data-price-source-last-sync={PRICE_SOURCE_LAST_SYNC}>
       <div className="mx-auto max-w-container">
-        <div className="mx-auto max-w-[680px] text-center">
-          <div className="eyebrow">Plans</div>
-          <h2 className="display-lg mt-3">Plans that scale with your pipeline.</h2>
-          <p className="font-body mt-4 text-[15px] leading-relaxed text-ink-500">
-            Start free, then pick the plan that matches your team. Switch or cancel any time.
-          </p>
-        </div>
-
-        {/* Monthly / Annual toggle */}
-        <div className="mt-10 flex justify-center">
-          <div
-            role="tablist"
-            aria-label="Billing period"
-            className="inline-flex items-center gap-1 rounded-full border border-ink-100 bg-white p-1 shadow-sm"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={billing === "monthly"}
-              onClick={() => setBilling("monthly")}
-              className={[
-                "font-display h-9 rounded-full px-4 text-[13px] font-semibold transition",
-                billing === "monthly"
-                  ? "bg-ink-900 text-white"
-                  : "text-ink-500 hover:text-ink-900",
-              ].join(" ")}
-            >
-              Monthly
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={billing === "annual"}
-              onClick={() => setBilling("annual")}
-              className={[
-                "font-display inline-flex h-9 items-center gap-2 rounded-full px-4 text-[13px] font-semibold transition",
-                billing === "annual"
-                  ? "bg-ink-900 text-white"
-                  : "text-ink-500 hover:text-ink-900",
-              ].join(" ")}
-            >
-              Annual
-              <span
-                className={[
-                  "font-mono inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
-                  billing === "annual"
-                    ? "bg-white/15 text-white"
-                    : "bg-brand-blue/10 text-brand-blue-700",
-                ].join(" ")}
-              >
-                Save ~25%
-              </span>
-            </button>
+        <div className="overflow-hidden rounded-[32px] border border-slate-800 bg-slate-950 px-6 py-9 text-white shadow-[0_32px_90px_rgba(2,6,23,0.22)] sm:px-10">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-[700px]">
+              <div className="font-display text-[11px] font-bold uppercase tracking-[0.16em] text-cyan-300">Simple plans. Real freight workflows.</div>
+              <h2 className="font-display mt-3 text-[34px] font-semibold leading-[1.05] tracking-[-0.035em] sm:text-[48px]">Choose the capacity your sales team needs now.</h2>
+              <p className="font-body mt-4 max-w-[620px] text-[15px] leading-relaxed text-slate-300">Every trial lasts 7 days and includes 10 searches plus 10 verified contacts. No credit card. Upgrade only when the workflow earns a place in your process.</p>
+            </div>
+            <div className="shrink-0">
+              <div className="inline-flex rounded-xl border border-white/10 bg-white/[0.06] p-1" role="group" aria-label="Billing period">
+                {(["monthly", "annual"] as const).map((period) => (
+                  <button key={period} type="button" aria-pressed={billing === period} onClick={() => setBilling(period)} className={["font-display rounded-lg px-4 py-2.5 text-[13px] font-semibold capitalize transition", billing === period ? "bg-white text-slate-950 shadow-sm" : "text-slate-300 hover:text-white"].join(" ")}>
+                    {period}{period === "annual" && <span className="ml-2 text-emerald-600">Save 25%</span>}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="mt-8 grid gap-3 border-t border-white/10 pt-6 sm:grid-cols-3">
+            {TRIAL_POINTS.map(({ icon: Icon, title, body }) => (
+              <div key={title} className="flex items-start gap-3 rounded-2xl bg-white/[0.04] p-4">
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-cyan-300" aria-hidden />
+                <div><div className="font-display text-[13px] font-semibold text-white">{title}</div><div className="font-body mt-1 text-[12px] leading-relaxed text-slate-400">{body}</div></div>
+              </div>
+            ))}
           </div>
         </div>
 
-        {/* Cards: 2x2 grid on desktop so each of the 4 tiers has breathing
-            room. Growth keeps the "Most popular" badge as the focal card. */}
-        <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="mt-8 grid grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-4">
           {TIERS.map((tier) => {
             const price = billing === "annual" ? tier.annual : tier.monthly;
-            const isCustom = price === null;
-
+            const custom = price === null;
             return (
-              <div
-                key={tier.id}
-                className={[
-                  "relative flex flex-col rounded-3xl border bg-white p-7 transition-all",
-                  tier.highlight
-                    ? "border-brand-blue/30 shadow-xl ring-1 ring-brand-blue/10"
-                    : "border-ink-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md",
-                ].join(" ")}
-              >
-                {tier.highlight && (
-                  <div
-                    className="absolute -top-3 left-1/2 -translate-x-1/2"
-                    aria-hidden={false}
-                  >
-                    <span className="font-display inline-flex items-center rounded-full bg-gradient-to-b from-brand-blue to-brand-blue-600 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-white shadow-[0_6px_18px_rgba(37,99,235,0.35)]">
-                      Most popular
-                    </span>
-                  </div>
-                )}
-
-                <div className="font-display text-[18px] font-semibold text-ink-900">
-                  {tier.name}
+              <article key={tier.id} className={["relative flex min-h-full flex-col overflow-hidden rounded-3xl border bg-white p-6 transition sm:p-7", tier.highlight ? "border-blue-500 shadow-[0_24px_64px_rgba(37,99,235,0.18)] ring-1 ring-blue-500/20" : "border-ink-100 shadow-sm hover:-translate-y-1 hover:shadow-lg"].join(" ")}>
+                {tier.highlight && <div className="absolute right-0 top-0 rounded-bl-2xl bg-blue-600 px-3 py-2 font-display text-[10px] font-bold uppercase tracking-[0.12em] text-white">Best for teams</div>}
+                <div className="font-display pr-14 text-[12px] font-bold uppercase tracking-[0.12em] text-brand-blue-700">{tier.bestFor}</div>
+                <h3 className="font-display mt-3 text-[25px] font-semibold tracking-[-0.025em] text-ink-900">{tier.name}</h3>
+                <p className="font-body mt-3 min-h-[72px] text-[13.5px] leading-relaxed text-ink-500">{tier.outcome}</p>
+                <div className="mt-6 border-y border-ink-100 py-5">
+                  {custom ? <><div className="font-display text-[35px] font-semibold leading-none text-ink-900">Custom</div><div className="font-body mt-2 text-[12px] text-ink-500">Scoped to seats, data, and governance.</div></> : <><div className="flex items-end gap-1.5"><span className="font-display text-[44px] font-semibold leading-none tracking-[-0.04em] text-ink-900">${price}</span><span className="font-body pb-1 text-[12px] text-ink-500">/ month</span></div><div className="font-body mt-2 text-[12px] text-ink-500">{billing === "annual" ? `$${tier.annualTotal?.toLocaleString()} billed annually` : "Billed month to month"}</div></>}
                 </div>
-                <p className="font-body mt-2 min-h-[44px] text-[13.5px] leading-relaxed text-ink-500">
-                  {tier.tagline}
-                </p>
-
-                <div className="mt-6">
-                  {isCustom ? (
-                    <div className="flex items-baseline gap-2">
-                      <span className="font-display text-[36px] font-semibold leading-none tracking-[-0.02em] text-ink-900">
-                        Custom
-                      </span>
-                    </div>
-                  ) : (
-                    <div className="flex items-baseline gap-1.5">
-                      <span className="font-display text-[44px] font-semibold leading-none tracking-[-0.02em] text-ink-900">
-                        ${price}
-                      </span>
-                      <span className="font-body text-[13px] text-ink-500">
-                        {tier.rhythm}
-                      </span>
-                    </div>
-                  )}
-                  {!isCustom && billing === "annual" && (
-                    <div className="font-body mt-2 text-[12.5px] text-ink-500">
-                      Billed annually.
-                    </div>
-                  )}
-                  {!isCustom && billing === "monthly" && (
-                    <div className="font-body mt-2 text-[12.5px] text-ink-500">
-                      Billed monthly.
-                    </div>
-                  )}
-                  {isCustom && (
-                    <div className="font-body mt-2 text-[12.5px] text-ink-500">
-                      Built around your seat count and data needs.
-                    </div>
-                  )}
-                </div>
-
-                <ul className="mt-6 space-y-2.5">
-                  {tier.features.map((f) => (
-                    <li key={f} className="flex items-start gap-2.5">
-                      <Check
-                        className="mt-0.5 h-4 w-4 shrink-0 text-brand-blue"
-                        aria-hidden
-                      />
-                      <span className="font-body text-[14px] leading-relaxed text-ink-700">
-                        {f}
-                      </span>
-                    </li>
-                  ))}
+                <div className="mt-5 font-display text-[11px] font-bold uppercase tracking-[0.11em] text-ink-500">What matters most</div>
+                <ul className="mt-3 space-y-3">
+                  {tier.highlights.map((feature) => <li key={feature} className="flex items-start gap-2.5"><span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-blue-50"><Check className="h-3.5 w-3.5 text-blue-700" aria-hidden /></span><span className="font-body text-[13.5px] leading-relaxed text-ink-700">{feature}</span></li>)}
                 </ul>
-
-                <div className="mt-7 flex-1" />
-                <Button
-                  variant={tier.highlight ? "primary" : "secondary"}
-                  size="lg"
-                  href={tier.cta.href}
-                  className="w-full justify-center"
-                >
-                  {tier.cta.label}
-                </Button>
-              </div>
+                <details className="group mt-5 border-t border-ink-100 pt-4">
+                  <summary className="font-display flex cursor-pointer list-none items-center justify-between text-[12.5px] font-semibold text-ink-700">See everything included<ChevronDown className="h-4 w-4 transition group-open:rotate-180" aria-hidden /></summary>
+                  <ul className="mt-4 space-y-2.5">{tier.details.map((feature) => <li key={feature} className="flex items-start gap-2 text-[12.5px] leading-relaxed text-ink-500"><Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden />{feature}</li>)}</ul>
+                </details>
+                <div className="mt-auto pt-7"><Button variant={tier.highlight ? "primary" : "secondary"} size="lg" href={tier.cta.href} className="w-full justify-center">{tier.cta.label}</Button></div>
+              </article>
             );
           })}
         </div>
-
-        <p className="font-body mt-8 text-center text-[12.5px] text-ink-500">
-          Prices in USD. Taxes and applicable fees billed separately.
-        </p>
+        <p className="font-body mt-7 text-center text-[12px] leading-relaxed text-ink-500">Prices are in USD. Usage resets each billing cycle. Gmail and Outlook sending are available; other integrations remain clearly marked as planned until released.</p>
       </div>
     </section>
   );

--- a/marketing/app/pricing/page.tsx
+++ b/marketing/app/pricing/page.tsx
@@ -23,7 +23,7 @@ const PRICING_FAQS = [
   {
     question: "Is there a free trial?",
     answer:
-      "Yes. Every account starts with a free trial — no credit card required. You get hands-on time with shipment search, contact reveals, and Pulse AI briefs so you can see whether LIT pays for itself before you pick a plan.",
+      "Yes. Every account starts with a 7-day trial with 10 searches and 10 verified-contact enrichments. No credit card is required. The trial is designed to let freight sales teams test real accounts before selecting a paid plan.",
   },
   {
     question: "Can I cancel anytime?",
@@ -46,9 +46,9 @@ const PRICING_FAQS = [
       "We'll notify you in-app before you hit your cap. You can either wait until the next billing cycle (caps reset automatically) or upgrade to the next tier — your reveal budget rebases instantly and we prorate the difference.",
   },
   {
-    question: "Do you offer a startup or non-profit discount?",
+    question: "Which integrations are available today?",
     answer:
-      "Yes. Early-stage startups (Series A and below) and registered non-profits qualify for discounted pricing on Starter and Growth. Talk to sales and we'll send you the application form.",
+      "Connected Gmail and Microsoft Outlook mailbox sending are available today. Other connectors are shown as planned on the integrations page until they are released; we do not present planned integrations as currently available.",
   },
   {
     question: "How does billing work for additional seats?",
@@ -86,7 +86,7 @@ export default function PricingPage() {
       priceCurrency: "USD",
       lowPrice: "125",
       highPrice: "999",
-      offerCount: 4,
+      offerCount: 3,
       availability: "https://schema.org/InStock",
       url: siteUrl(path),
       offers: [
@@ -120,16 +120,6 @@ export default function PricingPage() {
           availability: "https://schema.org/InStock",
           url: siteUrl(path),
         },
-        {
-          "@type": "Offer",
-          name: "Enterprise",
-          description:
-            "Custom pricing for multi-org programs. Unlimited usage, SSO + SCIM, Snowflake sync, custom data feeds, market benchmark analytics, named TAM, custom SLAs.",
-          price: "0",
-          priceCurrency: "USD",
-          availability: "https://schema.org/InStock",
-          url: siteUrl("/demo"),
-        },
       ],
     },
   };
@@ -155,9 +145,10 @@ export default function PricingPage() {
 
       <PageHero
         eyebrow="Pricing"
-        title="Freight prospecting that pays for itself in one booked lane."
-        subtitle="Start free. Pick a plan when you're ready. Cancel anytime."
-        primaryCta={{ label: "Start free trial", href: APP_SIGNUP_URL, icon: "arrow" }}
+        title="Plans built around"
+        titleHighlight="how freight sales teams work."
+        subtitle="Start with 7 days, 10 searches, and 10 verified contacts. Then choose the research capacity, contacts, and seats your team actually needs."
+        primaryCta={{ label: "Start 7-day trial", href: APP_SIGNUP_URL, icon: "arrow" }}
         secondaryCta={{ label: "Talk to sales", href: "/demo" }}
       />
 

--- a/marketing/app/sitemap.ts
+++ b/marketing/app/sitemap.ts
@@ -72,6 +72,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/3pl-leads`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${SITE_URL}/customs-broker-leads`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${SITE_URL}/logistics-sales-intelligence`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE_URL}/bill-of-lading-database`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE_URL}/freight-forwarder-crm`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     // /freight-leads industry sub-pages — previously missing from the sitemap.
     ...FREIGHT_LEAD_INDUSTRIES.map((ind) => ({
       url: `${SITE_URL}/freight-leads/${ind.slug}`,

--- a/marketing/components/nav/Footer.tsx
+++ b/marketing/components/nav/Footer.tsx
@@ -53,6 +53,8 @@ const FOOTER_COLUMNS: FooterColumn[] = [
       { label: "Blog", href: "/blog" },
       { label: "Customer stories", href: "/customers" },
       { label: "Trade intelligence", href: "/trade-intelligence" },
+      { label: "Bill of lading database", href: "/bill-of-lading-database" },
+      { label: "Freight forwarder CRM", href: "/freight-forwarder-crm" },
       { label: "Tariff calculator", href: "/tools/tariff-calculator" },
       { label: "All tools", href: "/tools" },
       { label: "Glossary", href: "/glossary" },
@@ -112,7 +114,7 @@ export function Footer() {
             <Link href="/" className="inline-flex items-center gap-2.5">
               <LitLogoMark size={28} />
               <span className="font-display text-[18px] font-bold tracking-[-0.02em] text-white">
-                Logistic{" "}
+                Logistics{" "}
                 <span className="font-extrabold" style={{ color: "#00F0FF" }}>
                   Intel
                 </span>

--- a/marketing/components/sections/SearchDemandPage.tsx
+++ b/marketing/components/sections/SearchDemandPage.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, Database, Search, Workflow } from "lucide-react";
+import { APP_SIGNUP_URL } from "@/lib/app-urls";
+import { siteUrl } from "@/lib/seo";
+import { BreadcrumbBar } from "./BreadcrumbBar";
+import { CtaBanner } from "./CtaBanner";
+import { PageShell } from "./PageShell";
+
+export type SearchDemandPageData = {
+  slug: string;
+  eyebrow: string;
+  title: string;
+  intro: string;
+  definition: string;
+  capabilities: { title: string; body: string }[];
+  workflow: { title: string; body: string }[];
+  faqs: { question: string; answer: string }[];
+  related: { href: string; label: string; body: string }[];
+};
+
+export function SearchDemandPage({ page }: { page: SearchDemandPageData }) {
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: page.faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    url: siteUrl(`/${page.slug}`),
+    description: page.intro,
+    about: { "@id": `${siteUrl("")}/#organization` },
+    isPartOf: { "@id": `${siteUrl("")}/#website` },
+  };
+
+  return (
+    <PageShell>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <BreadcrumbBar crumbs={[{ label: "Home", href: "/" }, { label: page.eyebrow }]} />
+
+      <section className="relative overflow-hidden px-5 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-24">
+        <div className="absolute inset-x-0 top-0 -z-10 h-[420px] bg-[radial-gradient(circle_at_50%_0%,rgba(37,99,235,0.13),transparent_65%)]" />
+        <div className="mx-auto max-w-content text-center">
+          <div className="lit-pill"><span className="dot" />{page.eyebrow}</div>
+          <h1 className="display-xl mx-auto mt-5 max-w-[920px]">{page.title}</h1>
+          <p className="lead mx-auto mt-6 max-w-[760px]">{page.intro}</p>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link href={APP_SIGNUP_URL} className="font-display inline-flex h-12 items-center gap-2 rounded-xl bg-blue-600 px-6 text-[14px] font-semibold text-white shadow-glow-blue transition hover:bg-blue-700">Start 7-day trial<ArrowRight className="h-4 w-4" /></Link>
+            <Link href="/demo" className="font-display inline-flex h-12 items-center rounded-xl border border-ink-100 bg-white px-6 text-[14px] font-semibold text-ink-900 shadow-sm transition hover:shadow-md">Book a demo</Link>
+          </div>
+          <p className="font-body mt-4 text-[12.5px] text-ink-500">10 searches + 10 verified contacts. No credit card.</p>
+        </div>
+      </section>
+
+      <section className="px-5 py-14 sm:px-8">
+        <div className="mx-auto grid max-w-content gap-7 rounded-3xl border border-ink-100 bg-white p-7 shadow-sm md:grid-cols-[0.8fr_1.2fr] md:p-10">
+          <div><div className="eyebrow">Plain-English definition</div><h2 className="display-md mt-3">What this category should actually do.</h2></div>
+          <p className="font-body text-[17px] leading-[1.75] text-ink-700">{page.definition}</p>
+        </div>
+      </section>
+
+      <section className="px-5 py-16 sm:px-8">
+        <div className="mx-auto max-w-content">
+          <div className="max-w-[680px]"><div className="eyebrow">Core capabilities</div><h2 className="display-lg mt-3">Useful data, tied to the sales decision.</h2></div>
+          <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {page.capabilities.map((item, index) => {
+              const icons = [Database, Search, Workflow];
+              const Icon = icons[index % icons.length];
+              return <article key={item.title} className="rounded-2xl border border-ink-100 bg-white p-6 shadow-sm"><span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50"><Icon className="h-5 w-5 text-blue-700" /></span><h3 className="display-sm mt-5">{item.title}</h3><p className="font-body mt-3 text-[14px] leading-relaxed text-ink-500">{item.body}</p></article>;
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-950 px-5 py-16 text-white sm:px-8 sm:py-20">
+        <div className="mx-auto max-w-content">
+          <div className="eyebrow text-cyan-300">From signal to action</div><h2 className="font-display mt-3 max-w-[720px] text-[34px] font-semibold leading-tight tracking-[-0.03em] sm:text-[46px]">A workflow a freight salesperson can use before the next call block.</h2>
+          <ol className="mt-10 grid gap-4 md:grid-cols-3">
+            {page.workflow.map((item, index) => <li key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.05] p-6"><div className="font-mono text-[11px] font-semibold text-cyan-300">0{index + 1}</div><h3 className="font-display mt-3 text-[18px] font-semibold">{item.title}</h3><p className="font-body mt-3 text-[13.5px] leading-relaxed text-slate-300">{item.body}</p></li>)}
+          </ol>
+        </div>
+      </section>
+
+      <section className="px-5 py-16 sm:px-8">
+        <div className="mx-auto max-w-[900px]"><div className="text-center"><div className="eyebrow">Frequently asked</div><h2 className="display-lg mt-3">Questions freight teams ask.</h2></div><div className="mt-9 space-y-3">{page.faqs.map((faq) => <details key={faq.question} className="group rounded-2xl border border-ink-100 bg-white p-5 shadow-sm"><summary className="font-display cursor-pointer list-none pr-6 text-[15px] font-semibold text-ink-900">{faq.question}</summary><p className="font-body mt-3 text-[14px] leading-relaxed text-ink-500">{faq.answer}</p></details>)}</div></div>
+      </section>
+
+      <section className="px-5 pb-16 sm:px-8"><div className="mx-auto max-w-content"><div className="eyebrow">Continue researching</div><div className="mt-5 grid gap-4 md:grid-cols-3">{page.related.map((item) => <Link key={item.href} href={item.href} className="group rounded-2xl border border-ink-100 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"><div className="flex items-center justify-between"><h3 className="font-display text-[15px] font-semibold text-ink-900">{item.label}</h3><ArrowRight className="h-4 w-4 text-blue-600 transition group-hover:translate-x-1" /></div><p className="font-body mt-2 text-[13px] leading-relaxed text-ink-500">{item.body}</p></Link>)}</div></div></section>
+
+      <CtaBanner eyebrow="See it on your accounts" title="Start with ten real searches, not a sales deck." subtitle="Use the 7-day trial to research accounts your team already knows. No credit card required." primaryCta={{ label: "Start 7-day trial", href: APP_SIGNUP_URL, icon: "arrow" }} secondaryCta={{ label: "Book a demo", href: "/demo" }} />
+    </PageShell>
+  );
+}

--- a/marketing/lib/seo.ts
+++ b/marketing/lib/seo.ts
@@ -37,7 +37,7 @@ export function buildMetadata(opts: {
   const description =
     seo.description ||
     opts.description ||
-    "LIT — market intelligence + revenue execution for modern growth teams.";
+    "Logistics Intel helps freight sales teams find active shippers, research trade lanes, reach relevant contacts, and organize qualified pipeline.";
   const url = `${SITE_URL}${opts.path}`;
   const canonical = seo.canonicalUrl || url;
 


### PR DESCRIPTION
## What changed

- Adds the required `uploadDate` to the Pulse Explorer `VideoObject` schema.
- Rebuilds pricing around buyer fit, a clear 7-day trial, expandable plan details, and a stronger Growth recommendation.
- Removes inaccurate claims that planned HubSpot and Salesforce connectors are currently included.
- Removes the invalid zero-dollar Enterprise offer from pricing structured data.
- Strengthens Organization entity markup and Logistics Intel naming consistency.
- Replaces remaining public “revenue teams” positioning with freight sales language.
- Adds substantive `/bill-of-lading-database` and `/freight-forwarder-crm` authority pages.
- Adds both pages to the sitemap and internal footer navigation.

## Validation

- Next.js production build passed.
- 114 pages generated.
- `git diff --check` passed.
- Marketing typecheck reaches an existing missing `vitest` declaration in `lib/title-normalizer.test.ts`; the application build and its type validation pass.