### PR TITLE
position Logistics Intel as a full freight-native CRM

### DIFF
--- a/marketing/app/command-center/page.tsx
+++ b/marketing/app/command-center/page.tsx
@@ -10,7 +10,7 @@ import { APP_SIGNUP_URL } from "@/lib/app-urls";
 export const metadata: Metadata = buildMetadata({
   title: "Freight CRM and Command Center | Logistics Intel",
   description:
-    "Manage saved shippers, prospects, contacts, campaign activity, notes, and pipeline stages in a freight-focused CRM workspace.",
+    "Manage freight accounts, contacts, deals, pipeline stages, weighted forecasts, tasks, reports, campaigns, and activity in one freight-native CRM.",
   path: "/command-center",
   eyebrow: "Command Center",
 });
@@ -18,36 +18,37 @@ export const metadata: Metadata = buildMetadata({
 const SECTIONS = [
   {
     icon: "Save",
-    tag: "Save the right companies",
-    title: "Turn searches into organized prospect lists",
-    body: "Build saved-company lists from any Pulse search, lane, industry, or HS code. Lists are the unit of outbound coordination — sales, BD, and ops can all work the same list.",
+    tag: "Shipment-aware accounts",
+    title: "Work every account with freight context attached",
+    body: "Save companies from Search or Pulse and keep shipment cadence, TEU, estimated spend, top routes, contacts, notes, tasks, campaigns, and deals on one shared account record.",
   },
   {
     icon: "GitMerge",
-    tag: "Pipeline stages",
-    title: "Move accounts through the freight buying cycle",
-    body: "Prospecting → Contacted → Engaged → Quoting → Won → Lost. Custom stages on Scale and Enterprise. Drag-and-drop board view + table view.",
+    tag: "Full deal pipeline",
+    title: "Move opportunities from new to won",
+    body: "Create deals, assign owners and contacts, set values and expected close dates, and move work through New, Qualified, Quoted, Negotiation, Won, and Lost on a visual pipeline board.",
   },
   {
     icon: "FileText",
-    tag: "Context attached",
-    title: "Notes, tasks, activity, and intelligence in one place",
-    body: "Every saved company holds shipment intelligence, contacts, notes, tasks, campaigns, and activity. Open the company, see everything that's happened on it.",
+    tag: "Tasks + activity",
+    title: "Keep the next action visible",
+    body: "Create and assign follow-up tasks, track due dates, capture deal activity, connect replies and meetings, and flag stale opportunities before they disappear from the forecast.",
   },
   {
     icon: "UsersRound",
-    tag: "Team workspace",
-    title: "Assign owners, manage lists, share visibility",
-    body: "Assign accounts to reps, manage shared lists, keep sales activity visible across the org. Role-based permissions on Scale and Enterprise.",
+    tag: "Forecasting + reports",
+    title: "See pipeline health without rebuilding a spreadsheet",
+    body: "Track open pipeline, active deals, weighted forecast, won revenue, tasks due, stage conversion, deal velocity, win/loss results, and owner performance from the same CRM workspace.",
   },
 ];
 
 const PIPELINE_STAGES = [
-  { name: "Prospecting", count: 28, tint: "#94a3b8" },
-  { name: "Contacted", count: 14, tint: "#3b82f6" },
-  { name: "Engaged", count: 9, tint: "#06b6d4" },
-  { name: "Quoting", count: 4, tint: "#f59e0b" },
-  { name: "Won", count: 2, tint: "#10b981" },
+  { name: "New", count: 18, tint: "#6366f1" },
+  { name: "Qualified", count: 11, tint: "#0ea5e9" },
+  { name: "Quoted", count: 7, tint: "#f59e0b" },
+  { name: "Negotiation", count: 4, tint: "#8b5cf6" },
+  { name: "Won", count: 3, tint: "#10b981" },
+  { name: "Lost", count: 2, tint: "#94a3b8" },
 ];
 
 export default function CommandCenterPage() {
@@ -55,31 +56,31 @@ export default function CommandCenterPage() {
     <PageShell>
       <ProductHero
         eyebrow="Command Center · Freight CRM"
-        title="A CRM workspace built around"
+        title="A full CRM built around"
         titleHighlight="freight opportunities."
-        subtitle="Command Center gives your team one place to manage saved companies, contacts, notes, tasks, campaigns, and pipeline movement. It is the bridge between intelligence and action — so reps stop maintaining a separate CRM that doesn't know what your buyers are shipping."
+        subtitle="Command Center connects shipment-aware accounts, contacts, deals, tasks, campaigns, pipeline forecasting, and performance reporting. Your reps can prospect, qualify, quote, follow up, and manage revenue without moving freight context into a generic CRM."
         visual={<PipelineMock />}
       />
 
       <FeatureGrid
         eyebrow="What's inside Command Center"
-        title="The CRM layer freight teams actually use."
+        title="The complete CRM workflow freight teams actually need."
         features={SECTIONS}
         cols={2}
       />
 
       <CtaBanner
-        eyebrow="Stop running two CRMs"
-        title="Move your freight pipeline into the same workspace as your intelligence."
-        subtitle="Free trial includes Command Center, saved-company lists, and pipeline tracking."
-        primaryCta={{ label: "Start free", href: APP_SIGNUP_URL, icon: "arrow" }}
+        eyebrow="From first signal to closed deal"
+        title="Run your freight pipeline in the same workspace as your intelligence."
+        subtitle="The 7-day trial includes Command Center accounts, deals, pipeline stages, tasks, forecasting, and reports."
+        primaryCta={{ label: "Start your 7-day trial", href: APP_SIGNUP_URL, icon: "arrow" }}
         secondaryCta={{ label: "Book a demo", href: "/demo" }}
       />
     </PageShell>
   );
 }
 
-/** Right-side hero visual — 5-stage pipeline board mock. */
+/** Right-side hero visual — six-stage pipeline board mock. */
 function PipelineMock() {
   return (
     <div className="rounded-2xl border border-ink-100 bg-white p-5 shadow-[0_30px_80px_-20px_rgba(15,23,42,0.18)]">
@@ -89,7 +90,7 @@ function PipelineMock() {
         </span>
         <span className="font-mono text-[10.5px] text-ink-200">Owner: Gabriel K.</span>
       </div>
-      <div className="mt-4 grid grid-cols-5 gap-1.5">
+      <div className="mt-4 grid grid-cols-3 gap-1.5 sm:grid-cols-6">
         {PIPELINE_STAGES.map((s) => (
           <div key={s.name} className="rounded-lg border border-ink-100 bg-white p-2.5 shadow-xs">
             <div className="font-display flex items-center justify-between gap-2">
@@ -118,7 +119,7 @@ function PipelineMock() {
         ))}
       </div>
       <div className="font-display mt-4 flex items-center justify-between rounded-lg bg-ink-25 px-3 py-2">
-        <span className="text-[11px] font-semibold text-ink-700">Pipeline value · $8.4M</span>
+        <span className="text-[11px] font-semibold text-ink-700">Open pipeline · $8.4M · Weighted forecast · $3.7M</span>
         <span
           className="font-mono inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9.5px] font-bold uppercase tracking-wider"
           style={{

--- a/marketing/app/features/_data.ts
+++ b/marketing/app/features/_data.ts
@@ -224,16 +224,18 @@ export const FEATURE_PAGES: FeaturePage[] = [
     lede:
       "Run your entire freight sales motion in one place. Accounts and contacts are pre-enriched with shipment data; deals carry lane, carrier, and volume context automatically.",
     shortAnswer:
-      "LIT CRM is a freight-native sales CRM with accounts, contacts, deals, sequences, and tasks. Every record is joined to live BOL data, so a customer record shows shipment cadence, lanes, and carrier mix — no separate enrichment tool required.",
+      "LIT CRM is a full freight-native sales CRM with shipment-aware accounts, contacts, deals, visual pipeline stages, tasks, activity timelines, weighted forecasting, win/loss tracking, and performance reports. Every record stays joined to live BOL data.",
     problem:
       "HubSpot and Salesforce are built for SaaS, not freight. Reps spend hours pasting BOL data into notes and re-enriching contacts from a third tool.",
     solution:
-      "LIT CRM treats shipments as a first-class field. Every account auto-displays its TTM TEU, top lanes, dominant carriers, last shipment date, and HS mix. Contacts are pre-enriched and continuously refreshed.",
+      "LIT CRM treats shipments as a first-class field and carries that context through the entire deal cycle. Every account displays shipment activity, lanes, carriers, contacts, tasks, campaigns, quotes, deals, and revenue activity in one workspace.",
     capabilities: [
       { title: "Shipment-aware accounts", body: "Each company shows TTM volume, lane mix, and carrier share automatically." },
-      { title: "Deal pipeline", body: "Stages, weighted forecasting, activity tracking — the basics, done well." },
+      { title: "Full deal pipeline", body: "New, Qualified, Quoted, Negotiation, Won, and Lost stages with deal values, owners, contacts, close dates, and drag-and-drop movement." },
+      { title: "Forecasting + reports", body: "Open pipeline, weighted forecast, won revenue, stage conversion, deal velocity, win/loss results, and owner performance." },
+      { title: "Tasks + activity", body: "Assigned follow-ups, due dates, deal timelines, reply and meeting activity, and stale-opportunity alerts." },
       { title: "Sequences in CRM", body: "Step-based outbound sequences with Pulse-AI personalization, no separate engagement tool needed." },
-      { title: "Two-way sync", body: "Optional bi-directional sync to HubSpot or Salesforce if you're not ready to migrate." },
+      { title: "Built-in CRM workflow", body: "Run account research, outreach, deals, tasks, forecasting, and reporting in LIT without maintaining a parallel generic CRM." },
       { title: "Watchlists + alerts", body: "Save lanes, ports, or accounts; get pinged when a meaningful change happens." },
     ],
     whoItsFor: [
@@ -249,7 +251,7 @@ export const FEATURE_PAGES: FeaturePage[] = [
       { label: "LIT vs Salesforce", href: "/vs/salesforce" },
     ],
     faqs: [
-      { q: "Can I run LIT alongside HubSpot?", a: "Yes — many teams do. Use LIT for prospecting + sequences and sync closed-won accounts back to HubSpot for finance/CS workflows." },
+      { q: "Can I run LIT alongside HubSpot or Salesforce?", a: "Yes. LIT can operate as your primary freight sales CRM today. HubSpot and Salesforce synchronization is shown on our integrations roadmap and should not be treated as a live connector until it is marked available." },
       { q: "Does it have a mobile app?", a: "Mobile web is fully responsive. A native app is on the 2026 roadmap." },
     ],
   },

--- a/marketing/app/page.tsx
+++ b/marketing/app/page.tsx
@@ -23,11 +23,11 @@ export const revalidate = 600; // ISR — refresh every 10 min
 
 const FALLBACK_HERO = {
   pillText: "Pulse AI · Global Supply Chain Research Intelligence",
-  headline: "Freight Prospecting Software for Brokers,",
+  headline: "Freight Prospecting & CRM Software for Brokers,",
   headlineHighlight: "Forwarders & 3PLs.",
   headlineSuffix: "",
   subhead:
-    "LIT helps freight forwarders, brokers, and logistics sales teams find active shippers, understand their trade activity, enrich verified contacts, and launch multichannel outreach — from one connected workspace built on 124M+ live Bill of Lading records.",
+    "LIT helps freight forwarders, brokers, and logistics sales teams find active shippers, understand their trade activity, reach verified contacts, and manage deals in a full freight-native CRM — from one connected workspace built on 124M+ live Bill of Lading records.",
   noteBelow:
     "Built for logistics teams that need better prospects, better timing, and better context before the first email goes out.",
   badges: [
@@ -76,10 +76,10 @@ const HERO_BADGE_ICONS: Record<string, LucideIcon> = {
 export const metadata: Metadata = buildMetadata({
   path: "/",
   title:
-    "Freight Prospecting Software for Brokers, Forwarders & 3PLs | Logistics Intel",
+    "Freight Prospecting & CRM Software for Logistics Sales | Logistics Intel",
   description:
-    "Logistics Intel turns live shipment data, verified contacts, and Pulse AI into pipeline — the freight prospecting platform for brokers, forwarders, and 3PLs.",
-  eyebrow: "Freight prospecting platform",
+    "Find active shippers, reach verified contacts, manage deals, forecast pipeline, and track tasks in a freight-native CRM for brokers, forwarders, and 3PLs.",
+  eyebrow: "Freight prospecting and CRM platform",
 });
 
 export default async function HomePage() {
@@ -139,7 +139,7 @@ export default async function HomePage() {
             applicationCategory: "BusinessApplication",
             operatingSystem: "Web",
             description:
-              "Market intelligence and revenue execution platform combining company data, trade signals, CRM, and outbound campaigns.",
+              "Freight prospecting and CRM platform combining shipment intelligence, verified contacts, deal pipelines, weighted forecasting, tasks, reporting, and outbound campaigns.",
             offers: {
               "@type": "Offer",
               price: "0",
@@ -160,7 +160,7 @@ function Hero({ hero }: { hero: any }) {
         eyebrow={hero.pillText}
         headline={
           <>
-            Freight Prospecting Software for <em>Brokers, Forwarders &amp; 3PLs</em>.
+            Freight Prospecting &amp; CRM Software for <em>Brokers, Forwarders &amp; 3PLs</em>.
           </>
         }
         lede={hero.subhead}

--- a/marketing/app/solutions/_data.ts
+++ b/marketing/app/solutions/_data.ts
@@ -52,7 +52,7 @@ export const SOLUTION_PAGES: SolutionPage[] = [
     faqs: [
       { q: "Is this only for US-inbound forwarders?", a: "Today, BOL coverage is strongest on US-inbound. Outbound corridors are growing — see /lanes for current coverage. International-only forwarders use LIT primarily for prospecting US importer accounts." },
       { q: "How fast can a 5-rep team ramp?", a: "Most teams send their first sequence within 2 weeks. Onboarding includes ICP setup, contact validation, and a first-campaign review." },
-      { q: "Can we keep using HubSpot or Salesforce?", a: "Yes — LIT syncs bi-directionally. Many teams use LIT for prospecting and sequencing, then sync closed-won accounts to their existing CRM." },
+      { q: "Can we keep using HubSpot or Salesforce?", a: "Yes. LIT can run as your primary freight sales CRM, while HubSpot and Salesforce synchronization remains on the integrations roadmap until those connectors are marked available." },
     ],
   },
   {


### PR DESCRIPTION
Updates the public marketing site to match the full CRM functionality now shipped in Command Center.

Changes:
- Homepage title, H1, description, and SoftwareApplication schema now position LIT as freight prospecting plus a full freight-native CRM.
- Command Center page reflects the real New → Qualified → Quoted → Negotiation → Won/Lost pipeline.
- Adds accurate deal ownership, values, close dates, tasks, activity, stale-deal detection, weighted forecasting, won revenue, reporting, and owner performance language.
- Replaces the outdated free-trial CTA with the current 7-day trial.
- Expands the freight-sales-CRM feature page to cover the shipped pipeline, forecasting, reporting, and activity functionality.
- Removes unsupported claims that HubSpot/Salesforce bi-directional synchronization is already live; those connectors remain explicitly on the roadmap.

Validation:
- git diff --check passes.
- Copy was matched against the shipped CRM commits and supplied production screenshots.