### PR TITLE
Build professional freight CRM SEO pages

### DIFF
--- a/marketing/app/features/_data.ts
+++ b/marketing/app/features/_data.ts
@@ -220,28 +220,28 @@ export const FEATURE_PAGES: FeaturePage[] = [
     titleHighlight: "built around shipments, not stages.",
     eyebrow: "CRM",
     metaDescription:
-      "A CRM for freight sales teams. Accounts, contacts, deals, and sequences — all attached to live shipment intelligence. No re-keying, no enrichment add-ons.",
+      "Freight CRM software for brokers, forwarders, and 3PLs. Manage accounts, contacts, deals, tasks, pipeline, forecasts, and reporting with shipment context attached.",
     lede:
-      "Run your entire freight sales motion in one place. Accounts and contacts are pre-enriched with shipment data; deals carry lane, carrier, and volume context automatically.",
+      "Manage the full freight sales process in one place. Accounts and contacts stay connected to shipment activity, while deals carry the lane, service, quote, owner, value, and follow-up context the team needs to move them forward.",
     shortAnswer:
       "LIT CRM is a full freight-native sales CRM with shipment-aware accounts, contacts, deals, visual pipeline stages, tasks, activity timelines, weighted forecasting, win/loss tracking, and performance reports. Every record stays joined to live BOL data.",
     problem:
-      "HubSpot and Salesforce are built for SaaS, not freight. Reps spend hours pasting BOL data into notes and re-enriching contacts from a third tool.",
+      "Most CRMs can store an account and a deal, but they do not explain why a shipper is worth pursuing. Freight reps end up rebuilding that context in notes, spreadsheets, and separate research tools before they can make the next call.",
     solution:
-      "LIT CRM treats shipments as a first-class field and carries that context through the entire deal cycle. Every account displays shipment activity, lanes, carriers, contacts, tasks, campaigns, quotes, deals, and revenue activity in one workspace.",
+      "LIT carries freight context through the entire deal cycle. Each account brings shipment activity, lanes, carriers, contacts, tasks, campaigns, quotes, deals, and revenue activity into the same workspace, so the record remains useful after prospecting ends.",
     capabilities: [
       { title: "Shipment-aware accounts", body: "Each company shows TTM volume, lane mix, and carrier share automatically." },
       { title: "Full deal pipeline", body: "New, Qualified, Quoted, Negotiation, Won, and Lost stages with deal values, owners, contacts, close dates, and drag-and-drop movement." },
       { title: "Forecasting + reports", body: "Open pipeline, weighted forecast, won revenue, stage conversion, deal velocity, win/loss results, and owner performance." },
       { title: "Tasks + activity", body: "Assigned follow-ups, due dates, deal timelines, reply and meeting activity, and stale-opportunity alerts." },
-      { title: "Sequences in CRM", body: "Step-based outbound sequences with Pulse-AI personalization, no separate engagement tool needed." },
+      { title: "Connected outreach", body: "Build step-based campaigns, send through connected Gmail or Microsoft Outlook mailboxes, and keep engagement tied to the account." },
       { title: "Built-in CRM workflow", body: "Run account research, outreach, deals, tasks, forecasting, and reporting in LIT without maintaining a parallel generic CRM." },
       { title: "Watchlists + alerts", body: "Save lanes, ports, or accounts; get pinged when a meaningful change happens." },
     ],
     whoItsFor: [
-      "Freight forwarders running a full outbound + AE motion.",
-      "3PL sales teams replacing spreadsheets with a real pipeline.",
-      "Customs brokers tracking active importers across HS chapters.",
+      "Freight forwarders managing shipper accounts across ocean, air, customs, and domestic services.",
+      "Freight brokers moving qualified shippers from first conversation through quote, negotiation, and close.",
+      "3PL and customs brokerage sales teams replacing disconnected spreadsheets with an accountable pipeline.",
     ],
     related: [
       { label: "Outbound campaigns", href: "/features/outbound-campaigns" },

--- a/marketing/app/freight-broker-crm/page.tsx
+++ b/marketing/app/freight-broker-crm/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { SearchDemandPage, type SearchDemandPageData } from "@/components/sections/SearchDemandPage";
+import { buildMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Freight Broker CRM for Shipper Sales Teams",
+  description:
+    "Manage shipper accounts, contacts, opportunities, quotes, tasks, pipeline, weighted forecasts, and sales reporting in a freight-native CRM.",
+  path: "/freight-broker-crm",
+  eyebrow: "Freight broker CRM",
+});
+
+const page: SearchDemandPageData = {
+  slug: "freight-broker-crm",
+  eyebrow: "Freight broker CRM",
+  title: "A freight broker CRM built around shippers, lanes, quotes, and the next move.",
+  intro:
+    "Logistics Intel gives brokerage sales teams one place to research active shippers, organize the right contacts, manage deals, schedule follow-ups, and forecast pipeline without separating the CRM from the freight context behind the opportunity.",
+  definition:
+    "A freight broker CRM should show more than a company name and a generic deal stage. It should preserve why the shipper is a fit, which lanes and services matter, who owns the relationship, what has happened, what was quoted, and what the rep needs to do next. That is the difference between a database the team maintains and a sales workspace the team can actually use.",
+  productPreview: "crm",
+  capabilities: [
+    {
+      title: "Shipper accounts with freight context",
+      body: "Keep shipment activity, estimated freight spend, lane patterns, contacts, notes, tasks, and deal history together on the account.",
+    },
+    {
+      title: "A pipeline that matches freight sales",
+      body: "Move opportunities through New, Qualified, Quoted, Negotiation, Won, and Lost with owners, values, close dates, services, and next steps visible.",
+    },
+    {
+      title: "Forecasts managers can inspect",
+      body: "Review open pipeline, weighted forecast, won revenue, deal velocity, stage conversion, win and loss results, and rep performance without rebuilding the report in a spreadsheet.",
+    },
+  ],
+  workflow: [
+    {
+      title: "Qualify the shipper",
+      body: "Review recent shipment activity, relevant lanes, service fit, and account signals before a rep spends time on outreach.",
+    },
+    {
+      title: "Work the account",
+      body: "Save the company, add the right contacts, assign an owner, create tasks, record activity, and keep the reason for pursuing the account visible.",
+    },
+    {
+      title: "Manage the deal",
+      body: "Track quotes and opportunity value, move the deal through the pipeline, monitor stale opportunities, and forecast what is realistically likely to close.",
+    },
+  ],
+  faqs: [
+    {
+      question: "What makes Logistics Intel a freight broker CRM?",
+      answer:
+        "The CRM is connected to the shipper research that starts the opportunity. Accounts can carry shipment activity, lane context, logistics contacts, deal values, service types, tasks, activity, quotes, forecasts, and reporting in one workspace.",
+    },
+    {
+      question: "Does the CRM support a complete deal pipeline?",
+      answer:
+        "Yes. Teams can manage New, Qualified, Quoted, Negotiation, Won, and Lost opportunities with owners, contacts, values, expected close dates, tasks, timelines, and weighted forecasting.",
+    },
+    {
+      question: "Can managers report on brokerage pipeline performance?",
+      answer:
+        "Yes. Command Center reporting covers open pipeline, weighted forecast, won revenue, stage conversion, deal velocity, win and loss outcomes, and performance by owner and service type.",
+    },
+    {
+      question: "Does Logistics Intel connect to email?",
+      answer:
+        "Connected Gmail and Microsoft Outlook sending are available. Other integrations remain marked as planned until they are released.",
+    },
+    {
+      question: "What is included in the trial?",
+      answer:
+        "The 7-day trial includes 10 searches and 10 verified contacts, with no credit card required. Paid plans and CRM access are described on the pricing page.",
+    },
+  ],
+  related: [
+    {
+      href: "/command-center",
+      label: "Command Center",
+      body: "See the account, pipeline, task, activity, forecast, and reporting workspace.",
+    },
+    {
+      href: "/freight-broker-leads",
+      label: "Freight broker leads",
+      body: "Find active shippers using shipment activity and freight-fit signals.",
+    },
+    {
+      href: "/pricing",
+      label: "Plans and pricing",
+      body: "Compare research, contact, CRM, support, and team-management options.",
+    },
+  ],
+};
+
+export default function FreightBrokerCrmPage() {
+  return <SearchDemandPage page={page} />;
+}

--- a/marketing/app/freight-forwarder-crm/page.tsx
+++ b/marketing/app/freight-forwarder-crm/page.tsx
@@ -15,6 +15,7 @@ const page: SearchDemandPageData = {
   title: "A freight sales CRM that already understands the account's shipment activity.",
   intro: "Command Center connects account ownership, contacts, tasks, outreach, and pipeline stages to the shipment and trade-lane context that freight forwarder sales teams use to qualify opportunities.",
   definition: "A freight forwarder CRM should manage more than names, notes, and deal stages. It should keep the account's shipment activity, lanes, products, contacts, research, follow-ups, and sales history together so the next action is based on freight context rather than an empty record created after the research is finished.",
+  productPreview: "crm",
   capabilities: [
     { title: "Account context from the beginning", body: "Start with company and shipment intelligence, then save the account with its lane, volume, carrier, supplier, and opportunity context attached." },
     { title: "Contacts tied to the shipper", body: "Organize relevant logistics, transportation, supply-chain, procurement, and import contacts alongside the company record and the reason the account was selected." },

--- a/marketing/app/sitemap.ts
+++ b/marketing/app/sitemap.ts
@@ -74,6 +74,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/logistics-sales-intelligence`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${SITE_URL}/bill-of-lading-database`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${SITE_URL}/freight-forwarder-crm`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE_URL}/freight-broker-crm`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     // /freight-leads industry sub-pages — previously missing from the sitemap.
     ...FREIGHT_LEAD_INDUSTRIES.map((ind) => ({
       url: `${SITE_URL}/freight-leads/${ind.slug}`,

--- a/marketing/components/sections/CrmPipelinePreview.tsx
+++ b/marketing/components/sections/CrmPipelinePreview.tsx
@@ -1,0 +1,80 @@
+import { BarChart3, CheckSquare2, DollarSign, Users2 } from "lucide-react";
+
+const metrics = [
+  { label: "Open pipeline", value: "$225K", icon: DollarSign, tone: "text-blue-600 bg-blue-50" },
+  { label: "Active deals", value: "18", icon: Users2, tone: "text-violet-600 bg-violet-50" },
+  { label: "Weighted forecast", value: "$148K", icon: BarChart3, tone: "text-cyan-700 bg-cyan-50" },
+  { label: "Tasks due", value: "6", icon: CheckSquare2, tone: "text-amber-600 bg-amber-50" },
+] as const;
+
+const stages = [
+  { name: "New", count: 8, value: "$82K", color: "bg-blue-500" },
+  { name: "Qualified", count: 5, value: "$96K", color: "bg-cyan-500" },
+  { name: "Quoted", count: 3, value: "$34K", color: "bg-amber-500" },
+  { name: "Negotiation", count: 2, value: "$13K", color: "bg-violet-500" },
+] as const;
+
+/** A lightweight, code-native product view. It avoids exposing customer data. */
+export function CrmPipelinePreview() {
+  return (
+    <div className="relative mx-auto max-w-container px-5 sm:px-8" aria-label="Logistics Intel CRM pipeline preview">
+      <div className="absolute -inset-6 -z-10 rounded-[40px] bg-[radial-gradient(circle_at_50%_20%,rgba(59,130,246,0.18),transparent_66%)] blur-2xl" />
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-2xl shadow-slate-950/25">
+        <div className="flex items-center justify-between border-b border-white/10 px-5 py-4 sm:px-7">
+          <div>
+            <p className="font-display text-[15px] font-semibold text-white">Command Center</p>
+            <p className="font-body mt-0.5 text-[11px] text-slate-400">Freight accounts, pipeline, tasks and reporting</p>
+          </div>
+          <span className="rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-cyan-300">
+            Live workspace
+          </span>
+        </div>
+
+        <div className="grid gap-3 border-b border-white/10 p-4 sm:grid-cols-2 sm:p-6 lg:grid-cols-4">
+          {metrics.map(({ label, value, icon: Icon, tone }) => (
+            <div key={label} className="rounded-xl border border-white/10 bg-white/[0.045] p-4">
+              <div className={`inline-flex h-8 w-8 items-center justify-center rounded-lg ${tone}`}>
+                <Icon className="h-4 w-4" aria-hidden />
+              </div>
+              <p className="font-display mt-4 text-[22px] font-semibold tracking-[-0.03em] text-white">{value}</p>
+              <p className="font-mono mt-1 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">{label}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="p-4 sm:p-6">
+          <div className="mb-4 flex items-end justify-between gap-4">
+            <div>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-cyan-300">Pipeline</p>
+              <p className="font-display mt-1 text-[17px] font-semibold text-white">Deals by freight sales stage</p>
+            </div>
+            <p className="hidden font-body text-[11px] text-slate-400 sm:block">Owners, values, next steps and close dates stay visible.</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {stages.map((stage, index) => (
+              <div key={stage.name} className="min-h-[154px] rounded-xl border border-white/10 bg-white/[0.035] p-3.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2 w-2 rounded-full ${stage.color}`} />
+                    <span className="font-display text-[12px] font-semibold text-white">{stage.name}</span>
+                  </div>
+                  <span className="font-mono text-[10px] text-slate-400">{stage.count}</span>
+                </div>
+                <p className="font-mono mt-1 text-[10px] text-slate-500">{stage.value}</p>
+                <div className="mt-4 rounded-lg border border-white/10 bg-slate-900 p-3">
+                  <p className="truncate font-display text-[11px] font-semibold text-slate-100">
+                    {index === 0 ? "New shipper opportunity" : index === 1 ? "Transpacific account" : index === 2 ? "Annual freight bid" : "Final rate review"}
+                  </p>
+                  <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-white/10">
+                    <div className={`h-full rounded-full ${stage.color}`} style={{ width: `${34 + index * 17}%` }} />
+                  </div>
+                  <p className="font-body mt-2 text-[9.5px] text-slate-500">Next step scheduled</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/marketing/components/sections/FeaturePageTemplate.tsx
+++ b/marketing/components/sections/FeaturePageTemplate.tsx
@@ -7,6 +7,7 @@ import { Section } from "@/components/sections/Section";
 import { BreadcrumbBar } from "@/components/sections/BreadcrumbBar";
 import { CtaBanner } from "@/components/sections/CtaBanner";
 import { HubCard } from "@/components/sections/HubCard";
+import { CrmPipelinePreview } from "@/components/sections/CrmPipelinePreview";
 import type { FeaturePage } from "@/app/features/_data";
 
 /**
@@ -38,16 +39,22 @@ export function FeaturePageTemplate({
         title={data.title}
         titleHighlight={data.titleHighlight}
         subtitle={data.lede}
-        primaryCta={{ label: "Try free", href: APP_SIGNUP_URL, icon: "arrow" }}
+        primaryCta={{ label: "Start 7-day trial", href: APP_SIGNUP_URL, icon: "arrow" }}
         secondaryCta={{ label: "Book a demo", href: "/demo" }}
       />
+
+      {data.slug === "freight-sales-crm" && (
+        <section className="pb-12 sm:pb-16">
+          <CrmPipelinePreview />
+        </section>
+      )}
 
       {/* AEO surface: a self-contained "short answer" paragraph LLMs and
           AI search overviews can quote verbatim. Kept above the fold. */}
       <Section top="none" bottom="md">
         <div className="rounded-2xl border border-ink-100 bg-white p-6 sm:p-8 shadow-sm">
           <div className="font-display text-[11px] font-bold uppercase tracking-[0.12em] text-brand-blue">
-            Short answer
+            In plain terms
           </div>
           <p className="font-body mt-3 text-[16px] leading-relaxed text-ink-700">
             {data.shortAnswer}
@@ -83,7 +90,7 @@ export function FeaturePageTemplate({
       <Section top="md" bottom="md">
         <div className="mb-8 sm:mb-10">
           <div className="eyebrow">Capabilities</div>
-          <h2 className="display-md mt-3">What's in the box.</h2>
+          <h2 className="display-md mt-3">What your team can do.</h2>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3">
           {data.capabilities.map((c) => (
@@ -105,7 +112,7 @@ export function FeaturePageTemplate({
         <Section top="md" bottom="md">
           <div className="mb-8 sm:mb-10 max-w-[640px]">
             <div className="eyebrow">Workflow</div>
-            <h2 className="display-md mt-3">From signal to booked freight.</h2>
+            <h2 className="display-md mt-3">From the first signal to a managed opportunity.</h2>
           </div>
           <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-3">
             {data.workflow.map((s, i) => (
@@ -125,7 +132,7 @@ export function FeaturePageTemplate({
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr,3fr]">
           <div>
             <div className="eyebrow">Who it's for</div>
-            <h2 className="display-md mt-3">Built around the team using it.</h2>
+            <h2 className="display-md mt-3">Designed for the people doing the work.</h2>
           </div>
           <ul className="space-y-3">
             {data.whoItsFor.map((p) => (
@@ -172,7 +179,7 @@ export function FeaturePageTemplate({
         <Section top="md" bottom="lg">
           <div className="mb-6 sm:mb-8">
             <div className="eyebrow">Related</div>
-            <h2 className="display-md mt-3">Keep digging.</h2>
+            <h2 className="display-md mt-3">Explore the connected workflow.</h2>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 lg:grid-cols-3">
             {data.related.map((r) => (
@@ -189,10 +196,10 @@ export function FeaturePageTemplate({
 
       <CtaBanner
         eyebrow="See it on your real data"
-        title="Book a 30-minute demo."
-        subtitle="We'll pull this exact view up against your top 5 target accounts so you can see the signal on lanes you actually sell into."
+        title="See how LIT fits your sales process."
+        subtitle="Bring a few target accounts or lanes to the demo. We will show you how the research, contacts, pipeline, and next steps come together."
         primaryCta={{ label: "Book a demo", href: "/demo", icon: "calendar" }}
-        secondaryCta={{ label: "Start free", href: APP_SIGNUP_URL }}
+        secondaryCta={{ label: "Start 7-day trial", href: APP_SIGNUP_URL }}
       />
 
       <Link

--- a/marketing/components/sections/SearchDemandPage.tsx
+++ b/marketing/components/sections/SearchDemandPage.tsx
@@ -4,6 +4,7 @@ import { APP_SIGNUP_URL } from "@/lib/app-urls";
 import { siteUrl } from "@/lib/seo";
 import { BreadcrumbBar } from "./BreadcrumbBar";
 import { CtaBanner } from "./CtaBanner";
+import { CrmPipelinePreview } from "./CrmPipelinePreview";
 import { PageShell } from "./PageShell";
 
 export type SearchDemandPageData = {
@@ -16,6 +17,7 @@ export type SearchDemandPageData = {
   workflow: { title: string; body: string }[];
   faqs: { question: string; answer: string }[];
   related: { href: string; label: string; body: string }[];
+  productPreview?: "crm";
 };
 
 export function SearchDemandPage({ page }: { page: SearchDemandPageData }) {
@@ -59,16 +61,22 @@ export function SearchDemandPage({ page }: { page: SearchDemandPageData }) {
         </div>
       </section>
 
+      {page.productPreview === "crm" && (
+        <section className="pb-10 sm:pb-16">
+          <CrmPipelinePreview />
+        </section>
+      )}
+
       <section className="px-5 py-14 sm:px-8">
         <div className="mx-auto grid max-w-content gap-7 rounded-3xl border border-ink-100 bg-white p-7 shadow-sm md:grid-cols-[0.8fr_1.2fr] md:p-10">
-          <div><div className="eyebrow">Plain-English definition</div><h2 className="display-md mt-3">What this category should actually do.</h2></div>
+          <div><div className="eyebrow">The practical definition</div><h2 className="display-md mt-3">What the software should help your team accomplish.</h2></div>
           <p className="font-body text-[17px] leading-[1.75] text-ink-700">{page.definition}</p>
         </div>
       </section>
 
       <section className="px-5 py-16 sm:px-8">
         <div className="mx-auto max-w-content">
-          <div className="max-w-[680px]"><div className="eyebrow">Core capabilities</div><h2 className="display-lg mt-3">Useful data, tied to the sales decision.</h2></div>
+          <div className="max-w-[680px]"><div className="eyebrow">Core capabilities</div><h2 className="display-lg mt-3">The context and controls to move an opportunity forward.</h2></div>
           <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
             {page.capabilities.map((item, index) => {
               const icons = [Database, Search, Workflow];
@@ -81,7 +89,7 @@ export function SearchDemandPage({ page }: { page: SearchDemandPageData }) {
 
       <section className="bg-slate-950 px-5 py-16 text-white sm:px-8 sm:py-20">
         <div className="mx-auto max-w-content">
-          <div className="eyebrow text-cyan-300">From signal to action</div><h2 className="font-display mt-3 max-w-[720px] text-[34px] font-semibold leading-tight tracking-[-0.03em] sm:text-[46px]">A workflow a freight salesperson can use before the next call block.</h2>
+          <div className="eyebrow text-cyan-300">From signal to action</div><h2 className="font-display mt-3 max-w-[720px] text-[34px] font-semibold leading-tight tracking-[-0.03em] sm:text-[46px]">A workflow built around the way freight sales teams actually work.</h2>
           <ol className="mt-10 grid gap-4 md:grid-cols-3">
             {page.workflow.map((item, index) => <li key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.05] p-6"><div className="font-mono text-[11px] font-semibold text-cyan-300">0{index + 1}</div><h3 className="font-display mt-3 text-[18px] font-semibold">{item.title}</h3><p className="font-body mt-3 text-[13.5px] leading-relaxed text-slate-300">{item.body}</p></li>)}
           </ol>
@@ -92,7 +100,7 @@ export function SearchDemandPage({ page }: { page: SearchDemandPageData }) {
         <div className="mx-auto max-w-[900px]"><div className="text-center"><div className="eyebrow">Frequently asked</div><h2 className="display-lg mt-3">Questions freight teams ask.</h2></div><div className="mt-9 space-y-3">{page.faqs.map((faq) => <details key={faq.question} className="group rounded-2xl border border-ink-100 bg-white p-5 shadow-sm"><summary className="font-display cursor-pointer list-none pr-6 text-[15px] font-semibold text-ink-900">{faq.question}</summary><p className="font-body mt-3 text-[14px] leading-relaxed text-ink-500">{faq.answer}</p></details>)}</div></div>
       </section>
 
-      <section className="px-5 pb-16 sm:px-8"><div className="mx-auto max-w-content"><div className="eyebrow">Continue researching</div><div className="mt-5 grid gap-4 md:grid-cols-3">{page.related.map((item) => <Link key={item.href} href={item.href} className="group rounded-2xl border border-ink-100 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"><div className="flex items-center justify-between"><h3 className="font-display text-[15px] font-semibold text-ink-900">{item.label}</h3><ArrowRight className="h-4 w-4 text-blue-600 transition group-hover:translate-x-1" /></div><p className="font-body mt-2 text-[13px] leading-relaxed text-ink-500">{item.body}</p></Link>)}</div></div></section>
+      <section className="px-5 pb-16 sm:px-8"><div className="mx-auto max-w-content"><div className="eyebrow">Explore the platform</div><div className="mt-5 grid gap-4 md:grid-cols-3">{page.related.map((item) => <Link key={item.href} href={item.href} className="group rounded-2xl border border-ink-100 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"><div className="flex items-center justify-between"><h3 className="font-display text-[15px] font-semibold text-ink-900">{item.label}</h3><ArrowRight className="h-4 w-4 text-blue-600 transition group-hover:translate-x-1" /></div><p className="font-body mt-2 text-[13px] leading-relaxed text-ink-500">{item.body}</p></Link>)}</div></div></section>
 
       <CtaBanner eyebrow="See it on your accounts" title="Start with ten real searches, not a sales deck." subtitle="Use the 7-day trial to research accounts your team already knows. No credit card required." primaryCta={{ label: "Start 7-day trial", href: APP_SIGNUP_URL, icon: "arrow" }} secondaryCta={{ label: "Book a demo", href: "/demo" }} />
     </PageShell>

--- a/marketing/next.config.mjs
+++ b/marketing/next.config.mjs
@@ -165,6 +165,10 @@ const nextConfig = {
       // onto the page that already targets the keyword.
       { source: "/freight-prospecting-software", destination: "/", permanent: true },
       { source: "/freight-sales-crm", destination: "/features/freight-sales-crm", permanent: true },
+      { source: "/freight-crm", destination: "/features/freight-sales-crm", permanent: true },
+      { source: "/logistics-sales-software", destination: "/solutions/logistics-sales-teams", permanent: true },
+      { source: "/import-data-for-sales", destination: "/trade-intelligence", permanent: true },
+      { source: "/shipper-lead-generation", destination: "/features/shipper-lead-generation", permanent: true },
       { source: "/importer-database", destination: "/features/importer-database", permanent: true },
       { source: "/bill-of-lading-data", destination: "/features/bill-of-lading-search", permanent: true },
       { source: "/trade-lane-intelligence", destination: "/features/trade-lane-intelligence", permanent: true },


### PR DESCRIPTION
## What changed

- adds a dedicated `/freight-broker-crm` commercial page after confirming the route did not already exist
- upgrades the existing freight-forwarder and freight-sales CRM pages with a branded, code-native Command Center pipeline preview
- rewrites shared page headings and CRM copy in direct, human language
- adds permanent redirects for proposed keyword aliases that overlap existing authoritative pages
- adds the new canonical page to the sitemap

## Why

Several proposed SEO routes already mapped to existing product, feature, or solution pages. Creating new pages for those terms would split relevance and internal authority. This change creates only the missing freight-broker CRM page and consolidates overlapping terms onto the strongest existing URL.

## Validation

- `git diff --check` passed locally
- route inventory confirmed existing pages before changes
- full TypeScript/build validation delegated to the Vercel preview because this scratch checkout does not have local dependencies installed
