### PR TITLE
Complete Lead CRM prospecting and workflow fixes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,6 +84,7 @@ const LeadCrmPipelinePage = lazy(() => import("@/pages/leadcrm/PipelinePage"));
 const LeadCrmTasksPage = lazy(() => import("@/pages/leadcrm/TasksPage"));
 const LeadCrmReportsPage = lazy(() => import("@/pages/leadcrm/ReportsPage"));
 const LeadCrmTeamPage = lazy(() => import("@/pages/leadcrm/TeamPage"));
+const LeadCrmFindLeadsPage = lazy(() => import("@/pages/leadcrm/FindLeadsPage"));
 
 const DEMO_MODE = !import.meta.env.VITE_SUPABASE_URL;
 
@@ -851,6 +852,7 @@ export default function App() {
           }
         >
           <Route index element={<LeadsListPage />} />
+          <Route path="find" element={<LeadCrmFindLeadsPage />} />
           <Route path="pipeline" element={<LeadCrmPipelinePage />} />
           <Route path="tasks" element={<LeadCrmTasksPage />} />
           <Route path="reports" element={<LeadCrmReportsPage />} />

--- a/frontend/src/features/crm/DealDetailDrawer.tsx
+++ b/frontend/src/features/crm/DealDetailDrawer.tsx
@@ -110,15 +110,17 @@ export default function DealDetailDrawer({
   useEffect(() => {
     let alive = true;
     (async () => {
-      if (!deal.saved_company_id) return;
       try {
         const { supabase } = await import("@/lib/supabase");
-        const { data } = await supabase
-          .from("lit_saved_companies")
-          .select("company_id")
-          .eq("id", deal.saved_company_id)
-          .maybeSingle();
-        const uuid = (data as any)?.company_id ?? null;
+        let uuid: string | null = deal.company_id ?? null;
+        if (deal.saved_company_id) {
+          const { data } = await supabase
+            .from("lit_saved_companies")
+            .select("company_id")
+            .eq("id", deal.saved_company_id)
+            .maybeSingle();
+          uuid = (data as any)?.company_id ?? uuid;
+        }
         if (alive) setCompanyUuid(uuid);
         const [list, att] = await Promise.all([
           listCompanyContacts(uuid),
@@ -513,12 +515,12 @@ export default function DealDetailDrawer({
               reporting counts the deal, never the linked quotes → no
               double-count. Attaching a quote does NOT overwrite deal value. */}
           <Section
-            title={`Quotes${linkedQuotes.length ? ` (${linkedQuotes.length})` : ""}`}
+            title={`Quotes${linkedQuotes.length + attachable.length ? ` (${linkedQuotes.length + attachable.length})` : ""}`}
           >
             <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              {linkedQuotes.length === 0 ? (
+              {linkedQuotes.length === 0 && attachable.length === 0 ? (
                 <div style={{ fontFamily: FONT_BODY, fontSize: 12, color: theme.textFaint }}>
-                  No quotes linked yet.
+                  No quotes generated for this account yet.
                 </div>
               ) : (
                 linkedQuotes.map((q) => (
@@ -572,6 +574,28 @@ export default function DealDetailDrawer({
                 ))
               )}
             </div>
+            {attachable.length > 0 ? (
+              <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: linkedQuotes.length ? 10 : 0 }}>
+                <div style={{ fontFamily: FONT_HEAD, fontSize: 10, fontWeight: 700, color: theme.textMuted, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                  Account quotes
+                </div>
+                {attachable.map((q) => (
+                  <div key={q.id} style={quoteRow(theme)}>
+                    <button
+                      onClick={() => { navigate(`/app/quoting/${q.id}`); onClose(); }}
+                      style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", textAlign: "left", background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", fontSize: 12.5, fontWeight: 600, color: mode === "dark" ? "#93C5FD" : "#1d4ed8" }}
+                      title="Open quote"
+                    >
+                      {q.quote_number ?? "Quote"}
+                    </button>
+                    <span style={quoteStatusPill(q.status, mode)}>{quoteStatusLabel(q.status)}</span>
+                    <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12.5, fontWeight: 700, color: theme.text, whiteSpace: "nowrap" }}>
+                      {formatMoney(q.total_sell ?? null, q.currency ?? deal.currency)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
             {/* Attach an existing (unlinked) company quote. */}
             {attachable.length > 0 ? (
               <div style={{ display: "flex", gap: 6, marginTop: 8 }}>

--- a/frontend/src/pages/leadcrm/FindLeadsPage.tsx
+++ b/frontend/src/pages/leadcrm/FindLeadsPage.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { ArrowLeft, Building2, Check, Loader2, MapPin, Search, Users } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import { createLead } from "@/api/leadCrm";
+import { useToast } from "@/components/ui/use-toast";
+import { CompanyAvatar } from "@/components/CompanyAvatar";
+import { FONT_BODY, FONT_HEAD } from "./leadCrmFormat";
+import { useLeadCrmTheme } from "./LeadCrmTheme";
+
+type ApolloCompany = {
+  id: string;
+  name: string;
+  domain: string | null;
+  website: string | null;
+  logo_url: string | null;
+  industry: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  employee_count: number | null;
+  linkedin_url: string | null;
+};
+
+const DEFAULT_KEYWORDS = "freight broker, freight forwarder";
+
+export default function FindLeadsPage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { theme } = useLeadCrmTheme();
+  const [keywords, setKeywords] = useState(DEFAULT_KEYWORDS);
+  const [location, setLocation] = useState("United States");
+  const [results, setResults] = useState<ApolloCompany[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [saved, setSaved] = useState<Set<string>>(new Set());
+  const [searching, setSearching] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [searched, setSearched] = useState(false);
+
+  const selectableIds = useMemo(() => results.filter((r) => !saved.has(r.id)).map((r) => r.id), [results, saved]);
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
+
+  async function runSearch() {
+    if (!keywords.trim()) return;
+    setSearching(true);
+    setSearched(true);
+    setSelected(new Set());
+    try {
+      const { data, error } = await supabase.functions.invoke("lead-crm-find-leads", {
+        body: { keywords: keywords.split(",").map((v) => v.trim()).filter(Boolean), location: location.trim() || null, page: 1, per_page: 50 },
+      });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || "Apollo search failed");
+      setResults(Array.isArray(data.companies) ? data.companies : []);
+    } catch (error: any) {
+      setResults([]);
+      toast({ title: "Search failed", description: error?.message || "Could not search Apollo.", variant: "destructive" });
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function toggle(id: string) {
+    if (saved.has(id)) return;
+    setSelected((current) => {
+      const next = new Set(current);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  async function saveCompanies(ids: string[]) {
+    const companies = results.filter((company) => ids.includes(company.id) && !saved.has(company.id));
+    if (!companies.length) return;
+    setSaving(true);
+    let success = 0;
+    const completed = new Set<string>();
+    for (const company of companies) {
+      try {
+        const result = await createLead({ companyName: company.name, notes: `Imported from Apollo${company.domain ? ` · ${company.domain}` : ""}` });
+        if (result.ok) { success += 1; completed.add(company.id); }
+      } catch { /* Continue bulk import and report the partial result. */ }
+    }
+    setSaved((current) => new Set([...current, ...completed]));
+    setSelected((current) => new Set([...current].filter((id) => !completed.has(id))));
+    setSaving(false);
+    toast({
+      title: success === companies.length ? "Leads saved" : "Import finished",
+      description: `${success} of ${companies.length} ${companies.length === 1 ? "company" : "companies"} added to the Lead CRM.`,
+      variant: success === 0 ? "destructive" : undefined,
+    });
+  }
+
+  return (
+    <div style={{ minHeight: "100%", background: theme.bg, color: theme.text, fontFamily: FONT_BODY }}>
+      <header style={{ padding: "18px 24px", borderBottom: `1px solid ${theme.border}`, background: theme.panel }}>
+        <button onClick={() => navigate("/app/leads")} style={linkButton(theme.textMuted)}><ArrowLeft size={14} /> Back to leads</button>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", gap: 16, flexWrap: "wrap", marginTop: 12 }}>
+          <div>
+            <div style={{ color: theme.accent, fontFamily: FONT_HEAD, fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase" }}>Apollo prospecting</div>
+            <h1 style={{ margin: "4px 0 0", fontFamily: FONT_HEAD, fontSize: 22, color: theme.heading }}>Find leads</h1>
+            <p style={{ margin: "4px 0 0", fontSize: 13, color: theme.textMuted }}>Search freight brokers and freight forwarders, then add one or many companies to the CRM.</p>
+          </div>
+          <button disabled={!selected.size || saving} onClick={() => saveCompanies([...selected])} style={primaryButton(theme, !selected.size || saving)}>
+            {saving ? <Loader2 size={14} className="animate-spin" /> : <Users size={14} />} Save selected {selected.size ? `(${selected.size})` : ""}
+          </button>
+        </div>
+      </header>
+
+      <main style={{ padding: 24, maxWidth: 1240, margin: "0 auto" }}>
+        <section style={{ display: "grid", gridTemplateColumns: "minmax(260px, 1fr) minmax(210px, .55fr) auto", gap: 10, padding: 16, border: `1px solid ${theme.border}`, borderRadius: 14, background: theme.panel }} className="max-md:!grid-cols-1">
+          <Field label="Company keywords" theme={theme}><input value={keywords} onChange={(e) => setKeywords(e.target.value)} onKeyDown={(e) => e.key === "Enter" && runSearch()} placeholder={DEFAULT_KEYWORDS} style={inputStyle(theme)} /></Field>
+          <Field label="Company location" theme={theme}><input value={location} onChange={(e) => setLocation(e.target.value)} onKeyDown={(e) => e.key === "Enter" && runSearch()} placeholder="United States" style={inputStyle(theme)} /></Field>
+          <button disabled={searching || !keywords.trim()} onClick={runSearch} style={{ ...primaryButton(theme, searching || !keywords.trim()), alignSelf: "end", height: 39 }}>
+            {searching ? <Loader2 size={15} className="animate-spin" /> : <Search size={15} />} Search Apollo
+          </button>
+        </section>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "18px 0 10px", minHeight: 28 }}>
+          <div style={{ fontFamily: FONT_HEAD, fontSize: 13, fontWeight: 700, color: theme.heading }}>{searched ? `${results.length} companies found` : "Ready to search"}</div>
+          {results.length > 0 ? <button onClick={() => setSelected(allSelected ? new Set() : new Set(selectableIds))} style={linkButton(theme.accent)}>{allSelected ? "Clear selection" : "Select all"}</button> : null}
+        </div>
+
+        {searching ? <Empty icon={<Loader2 className="animate-spin" />} title="Searching Apollo" detail="Finding companies that match your criteria…" theme={theme} />
+        : searched && !results.length ? <Empty icon={<Building2 />} title="No companies found" detail="Try broader keywords or a different location." theme={theme} />
+        : !searched ? <Empty icon={<Search />} title="Start with the freight market" detail="The default search is preloaded for U.S. freight brokers and freight forwarders." theme={theme} />
+        : <div style={{ display: "grid", gap: 8 }}>
+            {results.map((company) => {
+              const isSelected = selected.has(company.id); const isSaved = saved.has(company.id);
+              return <article key={company.id} onClick={() => toggle(company.id)} style={{ display: "grid", gridTemplateColumns: "auto minmax(0,1fr) auto", gap: 12, alignItems: "center", padding: 14, borderRadius: 12, border: `1px solid ${isSelected ? theme.accentBorder : theme.border}`, background: isSelected ? theme.accentSoft : theme.panel, cursor: isSaved ? "default" : "pointer" }}>
+                <CompanyAvatar company={{ name: company.name, domain: company.domain, logo_url: company.logo_url }} size={40} />
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontFamily: FONT_HEAD, fontSize: 14, fontWeight: 700, color: theme.heading, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{company.name}</div>
+                  <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 4, color: theme.textMuted, fontSize: 12 }}>
+                    {company.industry ? <span>{company.industry}</span> : null}
+                    {[company.city, company.state, company.country].filter(Boolean).length ? <span style={{ display: "inline-flex", gap: 4, alignItems: "center" }}><MapPin size={11} />{[company.city, company.state, company.country].filter(Boolean).join(", ")}</span> : null}
+                    {company.employee_count ? <span>{company.employee_count.toLocaleString()} employees</span> : null}
+                    {company.domain ? <span>{company.domain}</span> : null}
+                  </div>
+                </div>
+                {isSaved ? <span style={{ display: "inline-flex", gap: 5, alignItems: "center", color: "#059669", fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700 }}><Check size={14} /> Saved</span>
+                : <button onClick={(e) => { e.stopPropagation(); saveCompanies([company.id]); }} disabled={saving} style={secondaryButton(theme)}>{isSelected ? <Check size={14} /> : <Building2 size={14} />} {isSelected ? "Selected" : "Save"}</button>}
+              </article>;
+            })}
+          </div>}
+      </main>
+    </div>
+  );
+}
+
+function Field({ label, children, theme }: any) { return <label style={{ display: "grid", gap: 6 }}><span style={{ fontFamily: FONT_HEAD, fontSize: 11, fontWeight: 700, color: theme.textMuted }}>{label}</span>{children}</label>; }
+function Empty({ icon, title, detail, theme }: any) { return <div style={{ padding: "72px 20px", textAlign: "center", border: `1px dashed ${theme.borderStrong}`, borderRadius: 14, color: theme.textMuted }}><div style={{ width: 44, height: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", borderRadius: 12, background: theme.panelMuted }}>{React.cloneElement(icon, { size: 20 })}</div><div style={{ marginTop: 12, fontFamily: FONT_HEAD, fontWeight: 700, color: theme.heading }}>{title}</div><div style={{ marginTop: 4, fontSize: 13 }}>{detail}</div></div>; }
+function inputStyle(theme: any): React.CSSProperties { return { width: "100%", height: 39, borderRadius: 9, border: `1.5px solid ${theme.borderStrong}`, background: theme.inputBg, color: theme.text, padding: "0 11px", outline: "none", fontFamily: FONT_BODY, fontSize: 13 }; }
+function primaryButton(theme: any, disabled = false): React.CSSProperties { return { display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 7, padding: "9px 14px", border: 0, borderRadius: 9, background: theme.accent, color: theme.accentText, opacity: disabled ? .5 : 1, cursor: disabled ? "not-allowed" : "pointer", fontFamily: FONT_HEAD, fontSize: 12.5, fontWeight: 700 }; }
+function secondaryButton(theme: any): React.CSSProperties { return { display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 11px", borderRadius: 8, border: `1px solid ${theme.borderStrong}`, background: theme.panel, color: theme.text, fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700, cursor: "pointer" }; }
+function linkButton(color: string): React.CSSProperties { return { display: "inline-flex", alignItems: "center", gap: 6, border: 0, padding: 0, background: "transparent", color, fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700, cursor: "pointer" }; }

--- a/frontend/src/pages/leadcrm/LeadCrmLayout.tsx
+++ b/frontend/src/pages/leadcrm/LeadCrmLayout.tsx
@@ -18,7 +18,7 @@
 import React, { useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import {
-  Users, KanbanSquare, ListChecks, BarChart3, UserCog, Loader2, LogOut,
+  Users, KanbanSquare, ListChecks, BarChart3, UserCog, Loader2, LogOut, Search,
   ArrowLeft, Sun, Moon, Menu,
 } from "lucide-react";
 import { useAuth } from "@/auth/AuthProvider";
@@ -114,6 +114,7 @@ type NavItem = { to: string; end?: boolean; icon: React.ReactNode; label: string
 
 /** Human title per route for the top bar. */
 const SECTION_TITLES: { match: (p: string) => boolean; title: string }[] = [
+  { match: (p) => p.endsWith("/find"), title: "Find leads" },
   { match: (p) => p.endsWith("/pipeline"), title: "Pipeline" },
   { match: (p) => p.endsWith("/tasks"), title: "Tasks" },
   { match: (p) => p.endsWith("/reports"), title: "Reports" },
@@ -146,6 +147,7 @@ function LeadCrmShell() {
 
   const navItems: NavItem[] = [
     { to: "/app/leads", end: true, icon: <Users style={navIco} />, label: "Leads" },
+    { to: "/app/leads/find", icon: <Search style={navIco} />, label: "Find leads" },
     { to: "/app/leads/pipeline", icon: <KanbanSquare style={navIco} />, label: "Pipeline" },
     { to: "/app/leads/tasks", icon: <ListChecks style={navIco} />, label: "Tasks" },
     { to: "/app/leads/reports", icon: <BarChart3 style={navIco} />, label: "Reports" },

--- a/frontend/src/pages/leadcrm/LeadsListPage.tsx
+++ b/frontend/src/pages/leadcrm/LeadsListPage.tsx
@@ -32,6 +32,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import { CompanyAvatar } from "@/components/CompanyAvatar";
 import { useToast } from "@/components/ui/use-toast";
 import {
@@ -81,6 +82,7 @@ const STATUS_TABS: { value: LeadStatusFilter; label: string }[] = [
 export default function LeadsListPage() {
   const { toast } = useToast();
   const { theme } = useLeadCrmTheme();
+  const navigate = useNavigate();
   const [stageId, setStageId] = useState<string>("");
   const [source, setSource] = useState<string>("");
   const [assignee, setAssignee] = useState<string>("");
@@ -226,6 +228,14 @@ export default function LeadsListPage() {
               Work leads toward becoming subscribers
             </div>
           </div>
+          <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+          <button
+            type="button"
+            onClick={() => navigate("/app/leads/find")}
+            style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "9px 14px", borderRadius: 10, border: `1px solid ${theme.border}`, background: theme.panelAlt, color: theme.text, fontFamily: FONT_HEAD, fontSize: 12.5, fontWeight: 600, cursor: "pointer" }}
+          >
+            <Search style={{ width: 14, height: 14 }} /> Find leads
+          </button>
           <button
             type="button"
             onClick={() => setAddOpen(true)}
@@ -248,6 +258,7 @@ export default function LeadsListPage() {
             <Plus style={{ width: 14, height: 14 }} />
             Add opportunity
           </button>
+          </div>
         </div>
 
         {/* KPI row — Attio-style headline metrics + per-stage chips */}

--- a/supabase/functions/lead-crm-enrich-contacts/index.ts
+++ b/supabase/functions/lead-crm-enrich-contacts/index.ts
@@ -68,6 +68,46 @@ Deno.serve(async (req: Request) => {
     );
   }
 
+  // Domain/name-only leads need a canonical lit_companies UUID before Apollo
+  // results are persisted; lit_contacts.company_id is what the Lead CRM contact
+  // panel reads. Reuse an existing domain row or create one deterministic Apollo
+  // identity row, then link the lead before discovery/enrichment.
+  if (!lead.company_id) {
+    let companyId: string | null = null;
+    if (hasDomain) {
+      const { data: existing } = await admin
+        .from("lit_companies")
+        .select("id")
+        .eq("domain", lead.company_domain.trim().toLowerCase())
+        .limit(1)
+        .maybeSingle();
+      companyId = existing?.id ?? null;
+    }
+    if (!companyId) {
+      const key = hasDomain
+        ? lead.company_domain.trim().toLowerCase()
+        : `leadcrm-${leadId}`;
+      const { data: canonical, error: canonicalErr } = await admin
+        .from("lit_companies")
+        .upsert({
+          source: "apollo",
+          source_company_key: key,
+          name: hasName ? lead.company_name.trim() : key,
+          normalized_name: (hasName ? lead.company_name : key).trim().toLowerCase(),
+          domain: hasDomain ? lead.company_domain.trim().toLowerCase() : null,
+          website: hasDomain ? `https://${lead.company_domain.trim().toLowerCase()}` : null,
+        }, { onConflict: "source,source_company_key" })
+        .select("id")
+        .single();
+      if (canonicalErr || !canonical?.id) {
+        return json({ ok: false, error: "Could not create a company record for enrichment", code: "COMPANY_LINK_FAILED" }, 500);
+      }
+      companyId = canonical.id;
+    }
+    await admin.from("lit_admin_leads").update({ company_id: companyId, updated_at: new Date().toISOString() }).eq("id", leadId);
+    lead.company_id = companyId;
+  }
+
   // 4) Kill-switch check (respect the provider flag; apollo has no dedicated flag
   //    today so this defaults fail-open, matching the ledger's design invariant).
   const enabled = await isProviderEnabled(admin, PROVIDER_FLAGS.IMPORTYETI_ENABLED);
@@ -77,12 +117,65 @@ Deno.serve(async (req: Request) => {
     log.warn("provider_flag_disabled_but_apollo_uncontrolled", { lead_id: leadId });
   }
 
-  // 5) Forward to the product's orchestrator with the SAME user JWT. Passing
-  //    company_id lets the orchestrator discover + enrich the company's contacts
-  //    via the org's provider cascade; it self-gates + meters + writes lit_contacts.
+  // 5) Discover people at the company first. The enrichment orchestrator enriches
+  //    contact TARGETS; it does not turn a company id/domain into people. The old
+  //    wrapper skipped this step, so Apollo received no contacts and returned
+  //    NO_TARGETS even though APOLLO_API_KEY was valid.
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-  const orchestratorUrl = `${supabaseUrl}/functions/v1/enrich-contact-orchestrator`;
   const forwardAuth = req.headers.get("Authorization")!;
+
+  let discoveredContacts: any[] = [];
+  try {
+    const search = await fetch(`${supabaseUrl}/functions/v1/apollo-contact-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: forwardAuth,
+        apikey: Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      },
+      body: JSON.stringify({
+        company_id: lead.company_id ?? undefined,
+        domain: lead.company_domain ?? undefined,
+        company_name: lead.company_name ?? undefined,
+        titles: [
+          "Owner", "Founder", "President", "CEO", "Chief Executive Officer",
+          "VP Sales", "Vice President Sales", "Director of Sales",
+          "Operations Manager", "Director of Operations",
+        ],
+        seniorities: ["owner", "founder", "c_suite", "vp", "director", "manager"],
+        email_statuses: ["verified", "likely to engage"],
+        page: 1,
+        per_page: 25,
+      }),
+    });
+    const searchBody = await search.json().catch(() => ({}));
+    if (!search.ok || searchBody?.ok === false) {
+      return json({
+        ok: false,
+        error: searchBody?.message || searchBody?.error || "Contact discovery failed",
+        code: searchBody?.code || "CONTACT_DISCOVERY_FAILED",
+      }, search.status || 502);
+    }
+    discoveredContacts = Array.isArray(searchBody?.contacts) ? searchBody.contacts : [];
+  } catch (err) {
+    log.error("contact_discovery_failed", { err: String(err), lead_id: leadId });
+    return json({ ok: false, error: "Contact discovery service unavailable", code: "CONTACT_DISCOVERY_UNAVAILABLE" }, 502);
+  }
+
+  if (!discoveredContacts.length) {
+    return json({
+      ok: true,
+      provider: "apollo",
+      count: 0,
+      contacts: [],
+      exhausted: true,
+      credits_note: "No matching decision-makers were found — no enrichment credits consumed.",
+    });
+  }
+
+  // 6) Enrich the discovered people through the existing usage-gated provider
+  //    cascade. This is the path that persists rows into lit_contacts.
+  const orchestratorUrl = `${supabaseUrl}/functions/v1/enrich-contact-orchestrator`;
 
   let orchResp: any = null;
   let orchStatus = 0;
@@ -95,6 +188,7 @@ Deno.serve(async (req: Request) => {
         apikey: Deno.env.get("SUPABASE_ANON_KEY") ?? "",
       },
       body: JSON.stringify({
+        contacts: discoveredContacts,
         company_id: lead.company_id ?? undefined,
         domain: lead.company_domain ?? undefined,
         company_name: lead.company_name ?? undefined,
@@ -119,7 +213,7 @@ Deno.serve(async (req: Request) => {
   const count = Number(orchResp?.count ?? 0) || 0;
   const pending = orchResp?.pending === true;
 
-  // 6) CRM audit: activity row + provider_usage_events (attributes CRM spend).
+  // 7) CRM audit: activity row + provider_usage_events (attributes CRM spend).
   //    The orchestrator already consumed usage; this is an additional cost-ledger
   //    breadcrumb tagged to the lead-CRM feature. credits_consumed is left null so
   //    the ledger fills it from provider_pricing(apollo, contact_enrichment).

--- a/supabase/functions/lead-crm-find-leads/index.ts
+++ b/supabase/functions/lead-crm-find-leads/index.ts
@@ -1,0 +1,55 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const cors = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type", "Access-Control-Allow-Methods": "POST, OPTIONS" };
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
+const cleanDomain = (value: unknown) => String(value || "").replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0].toLowerCase() || null;
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  if (req.method !== "POST") return json({ ok: false, error: "Method not allowed" }, 405);
+
+  const url = Deno.env.get("SUPABASE_URL") || "";
+  const anon = Deno.env.get("SUPABASE_ANON_KEY") || "";
+  const service = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+  const apolloKey = Deno.env.get("APOLLO_API_KEY") || "";
+  const authorization = req.headers.get("Authorization") || "";
+  if (!authorization || !url || !anon || !service) return json({ ok: false, error: "Unauthorized" }, 401);
+
+  const caller = createClient(url, anon, { global: { headers: { Authorization: authorization } } });
+  const { data: userData, error: userError } = await caller.auth.getUser(authorization.replace(/^Bearer\s+/i, ""));
+  if (userError || !userData.user) return json({ ok: false, error: "Unauthorized" }, 401);
+  const { data: access } = await caller.rpc("lit_my_lead_crm_access");
+  const gate = Array.isArray(access) ? access[0] : access;
+  if (!gate?.is_member) return json({ ok: false, error: "Lead CRM membership required" }, 403);
+  if (!apolloKey) return json({ ok: false, error: "Apollo is not configured" }, 503);
+
+  let body: any = {};
+  try { body = await req.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+  const keywords = (Array.isArray(body.keywords) ? body.keywords : [body.keywords]).map((v: unknown) => String(v || "").trim()).filter(Boolean).slice(0, 10);
+  if (!keywords.length) return json({ ok: false, error: "At least one keyword is required" }, 400);
+  const page = Math.max(1, Math.min(100, Number(body.page) || 1));
+  const perPage = Math.max(1, Math.min(50, Number(body.per_page) || 50));
+
+  const apolloBody: Record<string, unknown> = { q_organization_keyword_tags: keywords, page, per_page: perPage };
+  if (body.location) apolloBody.organization_locations = [String(body.location).trim()];
+  const response = await fetch("https://api.apollo.io/api/v1/mixed_companies/search", { method: "POST", headers: { "Content-Type": "application/json", "Cache-Control": "no-cache", "X-Api-Key": apolloKey }, body: JSON.stringify(apolloBody) });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) return json({ ok: false, error: payload?.message || payload?.error || "Apollo search failed", provider_status: response.status }, response.status === 429 ? 429 : 502);
+
+  const rows = Array.isArray(payload?.organizations) ? payload.organizations : Array.isArray(payload?.accounts) ? payload.accounts : [];
+  const companies = rows.map((org: any) => ({
+    id: String(org.id || `${org.name || "company"}-${org.primary_domain || ""}`),
+    name: String(org.name || "Unnamed company"),
+    domain: cleanDomain(org.primary_domain || org.website_url),
+    website: org.website_url || (org.primary_domain ? `https://${org.primary_domain}` : null),
+    logo_url: org.logo_url || null,
+    industry: org.industry || null,
+    city: org.city || null,
+    state: org.state || null,
+    country: org.country || null,
+    employee_count: Number.isFinite(Number(org.estimated_num_employees)) ? Number(org.estimated_num_employees) : null,
+    linkedin_url: org.linkedin_url || null,
+  }));
+  return json({ ok: true, companies, pagination: payload?.pagination || { page, per_page: perPage }, provider: "apollo" });
+});

--- a/supabase/migrations/20260817200000_lit_leadcrm_update_lead_fix_array_append.sql
+++ b/supabase/migrations/20260817200000_lit_leadcrm_update_lead_fix_array_append.sql
@@ -1,0 +1,47 @@
+-- Repair lit_leadcrm_update_lead from 20260817100000.
+--
+-- The original function appended scalar labels with:
+--   v_changed := v_changed || 'title'
+-- PostgreSQL resolved the untyped literal as an array literal and raised 22P02
+-- before the UPDATE ran. Rebuild the existing function definition with
+-- unambiguous array_append(text[], text) calls. Keeping the rest of the
+-- deployed function definition intact prevents drift between this corrective
+-- migration and the original PATCH semantics.
+DO $migration$
+DECLARE
+  v_oid oid;
+  v_definition text;
+  v_fixed text;
+BEGIN
+  SELECT p.oid
+    INTO v_oid
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'lit_leadcrm_update_lead'
+    AND p.pronargs = 12;
+
+  IF v_oid IS NULL THEN
+    RAISE EXCEPTION 'public.lit_leadcrm_update_lead with 12 arguments was not found';
+  END IF;
+
+  SELECT pg_get_functiondef(v_oid) INTO v_definition;
+
+  v_fixed := regexp_replace(
+    v_definition,
+    $pattern$v_changed := v_changed \|\| '([^']+)'$pattern$,
+    $replacement$v_changed := array_append(v_changed, '\1'::text)$replacement$,
+    'g'
+  );
+
+  IF v_fixed = v_definition THEN
+    -- Idempotent when the live function has already received Claude's fix.
+    IF position('array_append(v_changed' IN v_definition) > 0 THEN
+      RETURN;
+    END IF;
+    RAISE EXCEPTION 'Expected v_changed array append expressions were not found';
+  END IF;
+
+  EXECUTE v_fixed;
+END
+$migration$;


### PR DESCRIPTION
Completes the interrupted Lead CRM update.

- fixes lead detail saves through the corrected RPC migration
- repairs Apollo contact discovery before enrichment
- adds Apollo organization search with freight broker/forwarder defaults
- supports single and bulk lead import into Lead CRM
- exposes account quotes in the deal drawer
- left-aligns Command Center tasks
- improves company-recognition guidance

Validation:
- Vercel preview production build passed on commit 6c151a4
- Supabase migration applied and verified
- lead-crm-enrich-contacts v4 active with JWT verification
- lead-crm-find-leads v1 active with JWT verification