### PR TITLE
Complete enriched-contact handoff to CRM communication

### DIFF
--- a/frontend/src/api/leadCrm.ts
+++ b/frontend/src/api/leadCrm.ts
@@ -127,9 +127,13 @@ export async function getSavedContactIds(contactIds: string[]): Promise<Set<stri
   return new Set((data ?? []).map((row: any) => String(row.contact_id)));
 }
 
-/** Save one or more enriched contacts for outreach, segmentation, and reporting. */
-export async function saveLeadContacts(contacts: Pick<LeadContact, "id">[], companyId?: string | null): Promise<number> {
-  if (!contacts.length) return 0;
+/** Save enriched contacts and promote the first selection to the CRM's primary contact. */
+export async function saveLeadContacts(
+  leadId: string,
+  contacts: LeadContact[],
+  companyId?: string | null,
+): Promise<{ saved: number; primaryUpdated: boolean }> {
+  if (!contacts.length) return { saved: 0, primaryUpdated: false };
   const { data: authData, error: authError } = await supabase.auth.getUser();
   if (authError || !authData.user) throw new Error(authError?.message || "Sign in required");
   const rows = contacts.map((contact) => ({
@@ -142,7 +146,22 @@ export async function saveLeadContacts(contacts: Pick<LeadContact, "id">[], comp
     .from("lit_saved_contacts")
     .upsert(rows, { onConflict: "user_id,contact_id", ignoreDuplicates: true });
   if (error) throw new Error(error.message);
-  return rows.length;
+
+  const primary = contacts[0];
+  const updated = await updateLead(leadId, {
+    fullName: primary.full_name,
+    email: primary.email,
+    phone: primary.phone,
+    title: primary.title,
+  });
+  if (!updated.ok) {
+    throw new Error(
+      updated.reason === "email_in_use"
+        ? "Contact saved, but this email already belongs to another CRM record."
+        : updated.reason || "Contact saved, but could not make it the primary contact.",
+    );
+  }
+  return { saved: rows.length, primaryUpdated: true };
 }
 
 /** Result of the enrich edge function. */

--- a/frontend/src/pages/leadcrm/LeadCompanyPanels.tsx
+++ b/frontend/src/pages/leadcrm/LeadCompanyPanels.tsx
@@ -216,12 +216,13 @@ export function ContactsPanel({ lead, onChanged }: { lead: Lead; onChanged?: () 
     if (!rows.length) return;
     setSaving(true);
     try {
-      await saveLeadContacts(rows, lead.company_id);
+      await saveLeadContacts(lead.id, rows, lead.company_id);
       setSavedIds((current) => new Set([...current, ...rows.map((contact) => contact.id)]));
       setSelected(new Set());
+      onChanged?.();
       toast({
         title: `Saved ${rows.length} contact${rows.length === 1 ? "" : "s"}`,
-        description: "Saved contacts remain linked to this company and its tags for segmentation and reporting.",
+        description: `${rows[0].full_name || "The selected contact"} is now the primary CRM contact and is ready in Communicate and campaigns.`,
       });
     } catch (e: any) {
       toast({ title: "Could not save contacts", description: e?.message, variant: "destructive" });

--- a/supabase/functions/lead-crm-enrich-contacts/index.ts
+++ b/supabase/functions/lead-crm-enrich-contacts/index.ts
@@ -213,6 +213,63 @@ Deno.serve(async (req: Request) => {
   const count = Number(orchResp?.count ?? 0) || 0;
   const pending = orchResp?.pending === true;
 
+  // Promote the best usable contact into the lead's primary contact fields.
+  // This is the handoff that makes enrichment immediately usable by the
+  // Communicate tab and campaign recipient flows. Never replace an existing
+  // primary email automatically; an explicit "Save selected" can do that.
+  if (count > 0 && lead.company_id) {
+    try {
+      const { data: currentLead } = await admin
+        .from("lit_admin_leads")
+        .select("full_name, email, phone, title")
+        .eq("id", leadId)
+        .maybeSingle();
+
+      if (currentLead && !currentLead.email) {
+        const { data: primary } = await admin
+          .from("lit_contacts")
+          .select("id, full_name, email, phone, title")
+          .eq("company_id", lead.company_id)
+          .not("email", "is", null)
+          .order("email_verified", { ascending: false })
+          .order("updated_at", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (primary?.email) {
+          const { error: promoteError } = await admin
+            .from("lit_admin_leads")
+            .update({
+              full_name: currentLead.full_name || primary.full_name,
+              email: primary.email,
+              phone: currentLead.phone || primary.phone,
+              title: currentLead.title || primary.title,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", leadId);
+
+          if (promoteError) {
+            log.warn("primary_contact_promotion_failed", {
+              lead_id: leadId,
+              contact_id: primary.id,
+              err: promoteError.message,
+            });
+          } else {
+            await admin.from("lit_lead_activity").insert({
+              lead_id: leadId,
+              kind: "primary_contact_assigned",
+              body: { contact_id: primary.id, source: "apollo_enrichment", automatic: true },
+              actor_user_id: user.id,
+              source: "system",
+            });
+          }
+        }
+      }
+    } catch (err) {
+      log.warn("primary_contact_promotion_threw", { lead_id: leadId, err: String(err) });
+    }
+  }
+
   // 7) CRM audit: activity row + provider_usage_events (attributes CRM spend).
   //    The orchestrator already consumed usage; this is an additional cost-ledger
   //    breadcrumb tagged to the lead-CRM feature. credits_consumed is left null so


### PR DESCRIPTION
## Summary
- automatically promotes the best usable enriched contact into empty primary CRM contact fields
- preserves an existing primary contact during later enrichment runs
- promotes the explicitly saved contact when the user uses Save selected
- refreshes the drawer immediately so Details and Communicate use the selected person
- keeps the production Edge Function source synchronized in the repository

## Existing data
Backfilled saved company contacts into empty primary lead records. CV International now resolves to Bill Smith with bsmith@cvinternational.com and the enriched title.

## Verification
- Supabase Edge Function v7 active with JWT verification
- live SQL confirms CV International primary contact fields are populated
- Vercel preview pending