### PR TITLE
Qualify Apollo companies before saving or enrichment

### DIFF
--- a/frontend/src/pages/leadcrm/FindLeadsPage.tsx
+++ b/frontend/src/pages/leadcrm/FindLeadsPage.tsx
@@ -22,6 +22,14 @@ type ApolloCompany = {
   country: string | null;
   employee_count: number | null;
   linkedin_url: string | null;
+  saved: boolean;
+  saved_lead_id: string | null;
+  saved_status: "active" | "archived" | "deleted" | null;
+  qualification_status: "unverified" | "qualified" | "disqualified" | "review";
+  qualification_company_type: string | null;
+  qualification_confidence: number | null;
+  qualification_reason: string | null;
+  safe_to_enrich: boolean;
 };
 
 const DEFAULT_KEYWORDS = "freight broker, freight forwarder";
@@ -53,10 +61,16 @@ export default function FindLeadsPage() {
   const [saved, setSaved] = useState<Set<string>>(new Set());
   const [searching, setSearching] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [verifying, setVerifying] = useState<Set<string>>(new Set());
   const [searched, setSearched] = useState(false);
   const [pagination, setPagination] = useState<ApolloPagination>(INITIAL_PAGINATION);
 
-  const selectableIds = useMemo(() => results.filter((r) => !saved.has(r.id)).map((r) => r.id), [results, saved]);
+  const selectableIds = useMemo(
+    () => results
+      .filter((r) => !r.saved && !saved.has(r.id) && !["disqualified", "review"].includes(r.qualification_status))
+      .map((r) => r.id),
+    [results, saved],
+  );
   const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
 
   async function runSearch(requestedPage = 1) {
@@ -75,6 +89,7 @@ export default function FindLeadsPage() {
       const totalEntries = Number(meta.total_entries ?? meta.totalEntries);
       const totalPages = Number(meta.total_pages ?? meta.totalPages);
       setResults(companies);
+      setSaved(new Set(companies.filter((company: ApolloCompany) => company.saved).map((company: ApolloCompany) => company.id)));
       setPagination({
         page: Number(meta.page) || requestedPage,
         perPage: Number(meta.per_page ?? meta.perPage) || PAGE_SIZE,
@@ -91,48 +106,108 @@ export default function FindLeadsPage() {
     }
   }
 
-  function toggle(id: string) {
-    if (saved.has(id)) return;
+  function toggle(company: ApolloCompany) {
+    if (company.saved || saved.has(company.id) || ["disqualified", "review"].includes(company.qualification_status)) return;
     setSelected((current) => {
       const next = new Set(current);
-      next.has(id) ? next.delete(id) : next.add(id);
+      next.has(company.id) ? next.delete(company.id) : next.add(company.id);
       return next;
     });
   }
 
+  async function qualifyCompany(company: ApolloCompany): Promise<ApolloCompany | null> {
+    if (company.safe_to_enrich) return company;
+    setVerifying((current) => new Set(current).add(company.id));
+    try {
+      const { data, error } = await supabase.functions.invoke("lead-crm-qualify-company", {
+        body: {
+          provider_company_id: company.id,
+          company_name: company.name,
+          domain: company.domain,
+          website: company.website,
+          linkedin_url: company.linkedin_url,
+          industry: company.industry,
+          location: [company.city, company.state, company.country].filter(Boolean).join(", ") || null,
+        },
+      });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || "Company verification failed");
+      const qualification = data.qualification;
+      const updated: ApolloCompany = {
+        ...company,
+        qualification_status: qualification.status,
+        qualification_company_type: qualification.company_type,
+        qualification_confidence: Number(qualification.confidence),
+        qualification_reason: qualification.reason,
+        safe_to_enrich: Boolean(qualification.safe_to_enrich),
+      };
+      setResults((current) => current.map((row) => row.id === company.id ? updated : row));
+      if (!updated.safe_to_enrich) {
+        toast({
+          title: updated.qualification_status === "disqualified" ? "Not a qualified lead" : "Manual review required",
+          description: updated.qualification_reason || "The company cannot proceed to enrichment.",
+          variant: "destructive",
+        });
+        return null;
+      }
+      return updated;
+    } catch (error: any) {
+      toast({ title: "Verification failed", description: error?.message || "Could not verify this company.", variant: "destructive" });
+      return null;
+    } finally {
+      setVerifying((current) => {
+        const next = new Set(current);
+        next.delete(company.id);
+        return next;
+      });
+    }
+  }
+
   async function saveCompanies(ids: string[]) {
-    const companies = results.filter((company) => ids.includes(company.id) && !saved.has(company.id));
+    const companies = results.filter((company) => ids.includes(company.id) && !company.saved && !saved.has(company.id));
     if (!companies.length) return;
     setSaving(true);
     let success = 0;
+    let rejected = 0;
     const completed = new Set<string>();
     for (const company of companies) {
+      const qualified = await qualifyCompany(company);
+      if (!qualified) {
+        rejected += 1;
+        continue;
+      }
       try {
-        const result = await createLead({
-          companyName: company.name,
-          notes: `Imported from Apollo · organization ${company.id}`,
+        const { data, error } = await supabase.rpc("lit_leadcrm_import_apollo_company", {
+          p_apollo_organization_id: qualified.id,
+          p_company_name: qualified.name,
+          p_website: qualified.website,
+          p_company_domain: qualified.domain,
+          p_logo_url: qualified.logo_url,
+          p_company_city: qualified.city,
+          p_company_state: qualified.state,
+          p_company_country: qualified.country,
         });
-        if (result.ok && result.lead_id) {
-          const updated = await updateLead(result.lead_id, {
-            companyName: company.name,
-            website: company.website || company.domain,
-            companyDomain: company.domain,
-            companyCity: company.city,
-            companyState: company.state,
-            companyCountry: company.country,
-          });
-          if (!updated.ok) throw new Error(updated.reason || "Company details were not saved");
-          success += 1;
-          completed.add(company.id);
-        }
-      } catch { /* Continue bulk import and report the partial result. */ }
+        if (error) throw error;
+        const result = Array.isArray(data) ? data[0] : data;
+        if (!result?.ok) throw new Error(result?.reason || "Company could not be saved");
+        success += 1;
+        completed.add(qualified.id);
+        setResults((current) => current.map((row) => row.id === qualified.id ? {
+          ...row,
+          saved: true,
+          saved_lead_id: result.lead_id,
+          saved_status: result.saved_status || "active",
+        } : row));
+      } catch (error: any) {
+        toast({ title: `Could not save ${qualified.name}`, description: error?.message || "Import failed.", variant: "destructive" });
+      }
     }
     setSaved((current) => new Set([...current, ...completed]));
     setSelected((current) => new Set([...current].filter((id) => !completed.has(id))));
     setSaving(false);
     toast({
-      title: success === companies.length ? "Leads saved" : "Import finished",
-      description: `${success} of ${companies.length} ${companies.length === 1 ? "company" : "companies"} added to the Lead CRM.`,
+      title: success ? "Qualified leads saved" : "No leads saved",
+      description: `${success} saved${rejected ? ` · ${rejected} rejected or held for review` : ""}.`,
       variant: success === 0 ? "destructive" : undefined,
     });
   }
@@ -191,8 +266,11 @@ export default function FindLeadsPage() {
         : !searched ? <Empty icon={<Search />} title="Start with the freight market" detail="The default search is preloaded for U.S. freight brokers and freight forwarders." theme={theme} />
         : <div style={{ display: "grid", gap: 8 }}>
             {results.map((company) => {
-              const isSelected = selected.has(company.id); const isSaved = saved.has(company.id);
-              return <article key={company.id} onClick={() => toggle(company.id)} style={{ display: "grid", gridTemplateColumns: "auto minmax(0,1fr) auto", gap: 12, alignItems: "center", padding: 14, borderRadius: 12, border: `1px solid ${isSelected ? theme.accentBorder : theme.border}`, background: isSelected ? theme.accentSoft : theme.panel, cursor: isSaved ? "default" : "pointer" }}>
+              const isSelected = selected.has(company.id);
+              const isSaved = company.saved || saved.has(company.id);
+              const isVerifying = verifying.has(company.id);
+              const isBlocked = ["disqualified", "review"].includes(company.qualification_status);
+              return <article key={company.id} onClick={() => toggle(company)} style={{ display: "grid", gridTemplateColumns: "auto minmax(0,1fr) auto", gap: 12, alignItems: "center", padding: 14, borderRadius: 12, border: `1px solid ${isSelected ? theme.accentBorder : theme.border}`, background: isSelected ? theme.accentSoft : theme.panel, cursor: isSaved || isBlocked ? "default" : "pointer" }}>
                 <CompanyAvatar name={company.name} domain={company.domain} logoUrl={company.logo_url} size="md" />
                 <div style={{ minWidth: 0 }}>
                   <div style={{ fontFamily: FONT_HEAD, fontSize: 14, fontWeight: 700, color: theme.heading, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{company.name}</div>
@@ -201,10 +279,20 @@ export default function FindLeadsPage() {
                     {[company.city, company.state, company.country].filter(Boolean).length ? <span style={{ display: "inline-flex", gap: 4, alignItems: "center" }}><MapPin size={11} />{[company.city, company.state, company.country].filter(Boolean).join(", ")}</span> : null}
                     {company.employee_count ? <span>{company.employee_count.toLocaleString()} employees</span> : null}
                     {company.domain ? <span>{company.domain}</span> : null}
+                    <span style={{ color: company.qualification_status === "qualified" ? "#059669" : company.qualification_status === "disqualified" ? "#dc2626" : theme.textMuted }}>
+                      {company.qualification_status === "qualified" ? `Verified · ${Math.round((company.qualification_confidence || 0) * 100)}%`
+                        : company.qualification_status === "disqualified" ? "Not a target"
+                        : company.qualification_status === "review" ? "Needs review"
+                        : "Not verified"}
+                    </span>
                   </div>
                 </div>
-                {isSaved ? <span style={{ display: "inline-flex", gap: 5, alignItems: "center", color: "#059669", fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700 }}><Check size={14} /> Saved</span>
-                : <button onClick={(e) => { e.stopPropagation(); saveCompanies([company.id]); }} disabled={saving} style={secondaryButton(theme)}>{isSelected ? <Check size={14} /> : <Building2 size={14} />} {isSelected ? "Selected" : "Save"}</button>}
+                {isSaved ? <span title={company.saved_status === "deleted" ? "This company was previously saved and later deleted." : undefined} style={{ display: "inline-flex", gap: 5, alignItems: "center", color: "#059669", fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700 }}><Check size={14} /> {company.saved_status === "deleted" ? "Previously saved" : "Saved"}</span>
+                : isBlocked ? <span title={company.qualification_reason || undefined} style={{ color: company.qualification_status === "disqualified" ? "#dc2626" : "#d97706", fontFamily: FONT_HEAD, fontSize: 12, fontWeight: 700 }}>{company.qualification_status === "disqualified" ? "Excluded" : "Review"}</span>
+                : <button onClick={(e) => { e.stopPropagation(); saveCompanies([company.id]); }} disabled={saving || isVerifying} style={secondaryButton(theme)}>
+                    {isVerifying ? <Loader2 size={14} className="animate-spin" /> : isSelected ? <Check size={14} /> : <Building2 size={14} />}
+                    {isVerifying ? "Verifying" : isSelected ? "Selected" : company.safe_to_enrich ? "Save" : "Verify & save"}
+                  </button>}
               </article>;
             })}
           </div>}

--- a/frontend/src/pages/leadcrm/FindLeadsPage.tsx
+++ b/frontend/src/pages/leadcrm/FindLeadsPage.tsx
@@ -4,7 +4,6 @@ import React, { useMemo, useRef, useState } from "react";
 import { ArrowLeft, Building2, Check, ChevronLeft, ChevronRight, Loader2, MapPin, Search, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
-import { createLead, updateLead } from "@/api/leadCrm";
 import { useToast } from "@/components/ui/use-toast";
 import { CompanyAvatar } from "@/components/CompanyAvatar";
 import { FONT_BODY, FONT_HEAD } from "./leadCrmFormat";

--- a/outreach_agent/agent.py
+++ b/outreach_agent/agent.py
@@ -1,12 +1,18 @@
-from __future__ import annotations
+from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
 
-from agents import Agent, Runner, trace
+from agents import Agent, Runner, WebSearchTool, trace
 
-from models import AgentResponse, OutreachDecision, OutreachRequest
+from models import (
+    AgentResponse,
+    LeadQualificationDecision,
+    LeadQualificationRequest,
+    OutreachDecision,
+    OutreachRequest,
+)
 from policies import assess_human_tone, forbidden_fact_claims, preflight_stop_reason
 from tools import check_approval_policy, get_channel_policy
 
@@ -34,6 +40,36 @@ def build_agent() -> Agent:
         tools=[get_channel_policy, check_approval_policy],
         output_type=OutreachDecision,
     )
+
+
+def build_qualification_agent() -> Agent:
+    return Agent(
+        name="LIT Lead Qualification Agent",
+        model=os.getenv("OUTREACH_AGENT_MODEL", "gpt-5.6-luna"),
+        instructions=(ROOT / "docs" / "qualification-prompt.md").read_text(encoding="utf-8"),
+        tools=[WebSearchTool()],
+        output_type=LeadQualificationDecision,
+    )
+
+
+async def run_lead_qualification(
+    request: LeadQualificationRequest,
+) -> LeadQualificationDecision:
+    _configure_api_key()
+    with trace(
+        "lit_lead_qualification",
+        metadata={
+            "request_id": request.request_id,
+            "provider": request.provider,
+            "provider_company_id": request.provider_company_id,
+        },
+    ):
+        result = await Runner.run(
+            build_qualification_agent(),
+            request.model_dump_json(),
+            max_turns=8,
+        )
+    return result.final_output
 
 
 def _input_payload(request: OutreachRequest, revision_feedback: list[str] | None = None) -> str:
@@ -103,4 +139,3 @@ async def run_outreach_agent(request: OutreachRequest) -> AgentResponse:
         revision_count=max_revisions,
         trace_id=getattr(workflow_trace, "trace_id", None),
     )
-

--- a/outreach_agent/docs/qualification-prompt.md
+++ b/outreach_agent/docs/qualification-prompt.md
@@ -1,0 +1,34 @@
+# LIT Lead Qualification Policy
+
+You audit Apollo company candidates before LIT spends credits on contact enrichment or begins outreach.
+
+Use web search for every company. Prefer the company's official website, then an independent authoritative source such as FMCSA, FMC, a state registration, a reputable business directory, or a credible company profile. Verify that the supplied domain belongs to the same company.
+
+## Ideal customer profile
+
+Return `qualified` only when current evidence shows the company directly operates as one or both of:
+
+- a freight broker that arranges transportation between shippers and carriers;
+- a freight forwarder, international forwarder, NVOCC, or forwarding operator that coordinates cargo movement.
+
+The company may also provide 3PL, customs brokerage, warehousing, trucking, or technology services. Those extra services do not disqualify it when brokerage or forwarding is a real operating service.
+
+## Mandatory exclusions
+
+Return `disqualified` when the organization is primarily a:
+
+- school, course, bootcamp, academy, coaching, or training business;
+- media brand, newsletter, podcast, conference, community, or influencer;
+- consultant or recruiting firm that does not itself broker or forward freight;
+- software, data, insurance, factoring, payment, compliance, or marketing vendor;
+- shipper, importer, manufacturer, carrier-only trucking company, warehouse-only operator, or other logistics-adjacent business with no brokerage or forwarding service.
+
+Names and Apollo categories are hints, never proof. For example, a company with “freight” or “logistics” in its name is not automatically qualified.
+
+## Decision standard
+
+- `qualified`: at least one strong source confirms freight brokerage or forwarding, confidence at least 0.75, and the domain identity is consistent.
+- `disqualified`: reliable evidence identifies a mandatory exclusion or a clearly different business.
+- `review`: sources conflict, the site cannot be verified, or evidence is too thin. `review` is never safe to enrich.
+
+Keep the reason concise and factual. Record the evidence URLs and describe exactly what each source establishes. Never invent licenses, services, locations, or affiliations. `safe_to_enrich` is true only for a qualified decision at or above the confidence threshold.

--- a/outreach_agent/main.py
+++ b/outreach_agent/main.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import asyncio
@@ -8,8 +8,8 @@ from pathlib import Path
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 
-from agent import run_outreach_agent
-from models import AgentResponse, OutreachRequest
+from agent import run_lead_qualification, run_outreach_agent
+from models import AgentResponse, LeadQualificationDecision, LeadQualificationRequest, OutreachRequest
 
 app = FastAPI(title="LIT Outreach Agent", version="0.1.0")
 
@@ -30,6 +30,15 @@ async def draft(request: OutreachRequest) -> AgentResponse:
     return await run_outreach_agent(request)
 
 
+@app.post(
+    "/v1/qualify",
+    response_model=LeadQualificationDecision,
+    dependencies=[Depends(authorize)],
+)
+async def qualify(request: LeadQualificationRequest) -> LeadQualificationDecision:
+    return await run_lead_qualification(request)
+
+
 async def _cli(input_path: Path) -> None:
     request = OutreachRequest.model_validate_json(input_path.read_text(encoding="utf-8"))
     response = await run_outreach_agent(request)
@@ -47,4 +56,3 @@ if __name__ == "__main__":
         parser.add_argument("--input", type=Path, default=Path("data/sample_request.json"))
         args = parser.parse_args()
         asyncio.run(_cli(args.input))
-

--- a/outreach_agent/models.py
+++ b/outreach_agent/models.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations
 
 from enum import Enum
 from typing import Literal
@@ -117,3 +117,47 @@ class AgentResponse(BaseModel):
     revision_count: int
     trace_id: str | None = None
 
+
+class LeadQualificationRequest(BaseModel):
+    request_id: str
+    provider: Literal["apollo"] = "apollo"
+    provider_company_id: str
+    company_name: str
+    domain: str | None = None
+    website: HttpUrl | None = None
+    linkedin_url: HttpUrl | None = None
+    industry: str | None = None
+    location: str | None = None
+    target_types: list[Literal["freight_broker", "freight_forwarder"]] = Field(
+        default_factory=lambda: ["freight_broker", "freight_forwarder"]
+    )
+
+
+class QualificationEvidence(BaseModel):
+    title: str
+    url: HttpUrl
+    finding: str
+
+
+class LeadQualificationDecision(BaseModel):
+    status: Literal["qualified", "disqualified", "review"]
+    company_type: Literal[
+        "freight_broker",
+        "freight_forwarder",
+        "freight_broker_and_forwarder",
+        "other_logistics",
+        "non_target",
+        "unknown",
+    ]
+    confidence: float = Field(ge=0, le=1)
+    verified_domain: str | None = None
+    reason: str
+    positive_signals: list[str] = Field(default_factory=list)
+    exclusion_signals: list[str] = Field(default_factory=list)
+    evidence: list[QualificationEvidence] = Field(default_factory=list)
+    safe_to_enrich: bool = False
+
+    @model_validator(mode="after")
+    def enforce_enrichment_gate(self) -> "LeadQualificationDecision":
+        self.safe_to_enrich = self.status == "qualified" and self.confidence >= 0.75
+        return self

--- a/outreach_agent/tests/test_policies.py
+++ b/outreach_agent/tests/test_policies.py
@@ -1,4 +1,4 @@
-from models import Channel, OutreachDecision, OutreachRequest
+from models import Channel, LeadQualificationDecision, OutreachDecision, OutreachRequest
 from policies import assess_human_tone, preflight_stop_reason
 
 
@@ -41,3 +41,20 @@ def test_grounded_plain_message_passes() -> None:
     assessment = assess_human_tone(decision, req)
     assert assessment.passed, assessment.failures
 
+
+def test_only_confident_qualified_company_is_safe_to_enrich() -> None:
+    qualified = LeadQualificationDecision(
+        status="qualified",
+        company_type="freight_broker",
+        confidence=0.88,
+        reason="Official site confirms freight brokerage services.",
+    )
+    uncertain = LeadQualificationDecision(
+        status="review",
+        company_type="unknown",
+        confidence=0.6,
+        reason="Evidence is incomplete.",
+        safe_to_enrich=True,
+    )
+    assert qualified.safe_to_enrich
+    assert not uncertain.safe_to_enrich

--- a/supabase/functions/lead-crm-find-leads/index.ts
+++ b/supabase/functions/lead-crm-find-leads/index.ts
@@ -1,9 +1,12 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2.57.4";
 
 const cors = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type", "Access-Control-Allow-Methods": "POST, OPTIONS" };
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
-const cleanDomain = (value: unknown) => String(value || "").replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0].toLowerCase() || null;
+const cleanDomain = (value: unknown) => String(value || "").replace(/^https?:\/\//i, "").replace(/^www\./i, "").split(/[/?#]/)[0].toLowerCase() || null;
+const canonicalName = (value: unknown) => String(value || "").toLowerCase().replace(/&/g, "and").replace(/[^a-z0-9]+/g, "").replace(/(inc|llc|ltd|corp|corporation|company|co)$/i, "");
+const apolloIdFromNotes = (value: unknown) => String(value || "").match(/organization\s+([A-Za-z0-9_-]+)/i)?.[1] || null;
+const domainFromNotes = (value: unknown) => cleanDomain(String(value || "").match(/Imported from Apollo\s*·\s*(\S+)/i)?.[1]);
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
@@ -24,9 +27,9 @@ Deno.serve(async (req) => {
   if (!gate?.is_member) return json({ ok: false, error: "Lead CRM membership required" }, 403);
   if (!apolloKey) return json({ ok: false, error: "Apollo is not configured" }, 503);
 
-  let body: any = {};
+  let body: Record<string, unknown> = {};
   try { body = await req.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
-  const keywords = (Array.isArray(body.keywords) ? body.keywords : [body.keywords]).map((v: unknown) => String(v || "").trim()).filter(Boolean).slice(0, 10);
+  const keywords = (Array.isArray(body.keywords) ? body.keywords : [body.keywords]).map((v) => String(v || "").trim()).filter(Boolean).slice(0, 10);
   if (!keywords.length) return json({ ok: false, error: "At least one keyword is required" }, 400);
   const page = Math.max(1, Math.min(100, Number(body.page) || 1));
   const perPage = Math.max(1, Math.min(50, Number(body.per_page) || 50));
@@ -37,19 +40,55 @@ Deno.serve(async (req) => {
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) return json({ ok: false, error: payload?.message || payload?.error || "Apollo search failed", provider_status: response.status }, response.status === 429 ? 429 : 502);
 
+  const admin = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
+  const [{ data: leadRows, error: leadsError }, { data: qualificationRows, error: qualificationError }] = await Promise.all([
+    admin.from("lit_admin_leads").select("id,company_name,company_domain,website,notes,apollo_organization_id,archived_at,deleted_at"),
+    admin.from("lit_lead_company_qualifications").select("provider_company_id,status,company_type,confidence,reason,checked_at,expires_at").eq("provider", "apollo"),
+  ]);
+  if (leadsError) console.error("saved lead lookup failed", leadsError);
+  if (qualificationError) console.error("qualification lookup failed", qualificationError);
+
+  const savedByApollo = new Map<string, any>();
+  const savedByDomain = new Map<string, any>();
+  const savedByName = new Map<string, any>();
+  for (const lead of leadRows || []) {
+    const apolloId = lead.apollo_organization_id || apolloIdFromNotes(lead.notes);
+    const domain = cleanDomain(lead.company_domain || lead.website) || domainFromNotes(lead.notes);
+    const name = canonicalName(lead.company_name);
+    if (apolloId) savedByApollo.set(String(apolloId), lead);
+    if (domain) savedByDomain.set(domain, lead);
+    if (name) savedByName.set(name, lead);
+  }
+  const qualifications = new Map((qualificationRows || []).map((row: any) => [String(row.provider_company_id), row]));
   const rows = Array.isArray(payload?.organizations) ? payload.organizations : Array.isArray(payload?.accounts) ? payload.accounts : [];
-  const companies = rows.map((org: any) => ({
-    id: String(org.id || `${org.name || "company"}-${org.primary_domain || ""}`),
-    name: String(org.name || "Unnamed company"),
-    domain: cleanDomain(org.primary_domain || org.website_url),
-    website: org.website_url || (org.primary_domain ? `https://${org.primary_domain}` : null),
-    logo_url: org.logo_url || null,
-    industry: org.industry || null,
-    city: org.city || null,
-    state: org.state || null,
-    country: org.country || null,
-    employee_count: Number.isFinite(Number(org.estimated_num_employees)) ? Number(org.estimated_num_employees) : null,
-    linkedin_url: org.linkedin_url || null,
-  }));
+  const companies = rows.map((org: any) => {
+    const id = String(org.id || `${org.name || "company"}-${org.primary_domain || ""}`);
+    const domain = cleanDomain(org.primary_domain || org.website_url);
+    const existing = savedByApollo.get(id) || (domain ? savedByDomain.get(domain) : null) || savedByName.get(canonicalName(org.name));
+    const qualification: any = qualifications.get(id);
+    const qualificationFresh = qualification && new Date(qualification.expires_at).getTime() > Date.now();
+    const savedStatus = existing ? existing.deleted_at ? "deleted" : existing.archived_at ? "archived" : "active" : null;
+    return {
+      id,
+      name: String(org.name || "Unnamed company"),
+      domain,
+      website: org.website_url || (org.primary_domain ? `https://${org.primary_domain}` : null),
+      logo_url: org.logo_url || (domain ? `https://img.logo.dev/${domain}?size=160` : null),
+      industry: org.industry || null,
+      city: org.city || null,
+      state: org.state || null,
+      country: org.country || null,
+      employee_count: Number.isFinite(Number(org.estimated_num_employees)) ? Number(org.estimated_num_employees) : null,
+      linkedin_url: org.linkedin_url || null,
+      saved: Boolean(existing),
+      saved_lead_id: existing?.id || null,
+      saved_status: savedStatus,
+      qualification_status: qualificationFresh ? qualification.status : "unverified",
+      qualification_company_type: qualificationFresh ? qualification.company_type : null,
+      qualification_confidence: qualificationFresh ? Number(qualification.confidence) : null,
+      qualification_reason: qualificationFresh ? qualification.reason : null,
+      safe_to_enrich: Boolean(qualificationFresh && qualification.status === "qualified" && Number(qualification.confidence) >= 0.75),
+    };
+  });
   return json({ ok: true, companies, pagination: payload?.pagination || { page, per_page: perPage }, provider: "apollo" });
 });

--- a/supabase/functions/lead-crm-find-leads/index.ts
+++ b/supabase/functions/lead-crm-find-leads/index.ts
@@ -12,10 +12,9 @@ Deno.serve(async (req) => {
 
   const url = Deno.env.get("SUPABASE_URL") || "";
   const anon = Deno.env.get("SUPABASE_ANON_KEY") || "";
-  const service = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
   const apolloKey = Deno.env.get("APOLLO_API_KEY") || "";
   const authorization = req.headers.get("Authorization") || "";
-  if (!authorization || !url || !anon || !service) return json({ ok: false, error: "Unauthorized" }, 401);
+  if (!authorization || !url || !anon) return json({ ok: false, error: "Unauthorized" }, 401);
 
   const caller = createClient(url, anon, { global: { headers: { Authorization: authorization } } });
   const { data: userData, error: userError } = await caller.auth.getUser(authorization.replace(/^Bearer\s+/i, ""));
@@ -39,19 +38,11 @@ Deno.serve(async (req) => {
   if (!response.ok) return json({ ok: false, error: payload?.message || payload?.error || "Apollo search failed", provider_status: response.status }, response.status === 429 ? 429 : 502);
 
   const rows = Array.isArray(payload?.organizations) ? payload.organizations : Array.isArray(payload?.accounts) ? payload.accounts : [];
-  const apolloIds = rows.map((org: any) => String(org.id || "")).filter(Boolean);
-  const admin = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
-  const [{ data: leadEnvelope, error: leadsError }, { data: qualificationRows, error: qualificationError }] = await Promise.all([
-    caller.rpc("lit_leadcrm_list_leads", {
-      p_stage_id: null, p_source: null, p_assignee: null, p_q: null,
-      p_limit: 500, p_offset: 0, p_status: "all",
-    }),
-    admin.from("lit_lead_company_qualifications")
-      .select("provider_company_id,status,company_type,confidence,reason,checked_at,expires_at")
-      .eq("provider", "apollo").in("provider_company_id", apolloIds),
-  ]);
+  const { data: leadEnvelope, error: leadsError } = await caller.rpc("lit_leadcrm_list_leads", {
+    p_stage_id: null, p_source: null, p_assignee: null, p_q: null,
+    p_limit: 500, p_offset: 0, p_status: "all",
+  });
   if (leadsError) console.error("saved lead lookup failed", leadsError);
-  if (qualificationError) console.error("qualification lookup failed", qualificationError);
 
   const leadRows = Array.isArray((leadEnvelope as any)?.leads) ? (leadEnvelope as any).leads : [];
   const savedByDomain = new Map<string, any>();
@@ -62,13 +53,10 @@ Deno.serve(async (req) => {
     if (domain) savedByDomain.set(domain, lead);
     if (name) savedByName.set(name, lead);
   }
-  const qualifications = new Map((qualificationRows || []).map((row: any) => [String(row.provider_company_id), row]));
   const companies = rows.map((org: any) => {
     const id = String(org.id || `${org.name || "company"}-${org.primary_domain || ""}`);
     const domain = cleanDomain(org.primary_domain || org.website_url);
     const existing = (domain ? savedByDomain.get(domain) : null) || savedByName.get(canonicalName(org.name));
-    const qualification: any = qualifications.get(id);
-    const qualificationFresh = qualification && new Date(qualification.expires_at).getTime() > Date.now();
     const savedStatus = existing ? existing.deleted_at ? "deleted" : existing.archived_at ? "archived" : "active" : null;
     return {
       id,
@@ -85,11 +73,11 @@ Deno.serve(async (req) => {
       saved: Boolean(existing),
       saved_lead_id: existing?.id || null,
       saved_status: savedStatus,
-      qualification_status: qualificationFresh ? qualification.status : "unverified",
-      qualification_company_type: qualificationFresh ? qualification.company_type : null,
-      qualification_confidence: qualificationFresh ? Number(qualification.confidence) : null,
-      qualification_reason: qualificationFresh ? qualification.reason : null,
-      safe_to_enrich: Boolean(qualificationFresh && qualification.status === "qualified" && Number(qualification.confidence) >= 0.75),
+      qualification_status: "unverified",
+      qualification_company_type: null,
+      qualification_confidence: null,
+      qualification_reason: null,
+      safe_to_enrich: false,
     };
   });
   return json({ ok: true, companies, pagination: payload?.pagination || { page, per_page: perPage }, provider: "apollo" });

--- a/supabase/functions/lead-crm-find-leads/index.ts
+++ b/supabase/functions/lead-crm-find-leads/index.ts
@@ -5,8 +5,6 @@ const cors = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
 const cleanDomain = (value: unknown) => String(value || "").replace(/^https?:\/\//i, "").replace(/^www\./i, "").split(/[/?#]/)[0].toLowerCase() || null;
 const canonicalName = (value: unknown) => String(value || "").toLowerCase().replace(/&/g, "and").replace(/[^a-z0-9]+/g, "").replace(/(inc|llc|ltd|corp|corporation|company|co)$/i, "");
-const apolloIdFromNotes = (value: unknown) => String(value || "").match(/organization\s+([A-Za-z0-9_-]+)/i)?.[1] || null;
-const domainFromNotes = (value: unknown) => cleanDomain(String(value || "").match(/Imported from Apollo\s*·\s*(\S+)/i)?.[1]);
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
@@ -40,31 +38,35 @@ Deno.serve(async (req) => {
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) return json({ ok: false, error: payload?.message || payload?.error || "Apollo search failed", provider_status: response.status }, response.status === 429 ? 429 : 502);
 
+  const rows = Array.isArray(payload?.organizations) ? payload.organizations : Array.isArray(payload?.accounts) ? payload.accounts : [];
+  const apolloIds = rows.map((org: any) => String(org.id || "")).filter(Boolean);
   const admin = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
-  const [{ data: leadRows, error: leadsError }, { data: qualificationRows, error: qualificationError }] = await Promise.all([
-    admin.from("lit_admin_leads").select("id,company_name,company_domain,website,notes,apollo_organization_id,archived_at,deleted_at"),
-    admin.from("lit_lead_company_qualifications").select("provider_company_id,status,company_type,confidence,reason,checked_at,expires_at").eq("provider", "apollo"),
+  const [{ data: leadEnvelope, error: leadsError }, { data: qualificationRows, error: qualificationError }] = await Promise.all([
+    caller.rpc("lit_leadcrm_list_leads", {
+      p_stage_id: null, p_source: null, p_assignee: null, p_q: null,
+      p_limit: 500, p_offset: 0, p_status: "all",
+    }),
+    admin.from("lit_lead_company_qualifications")
+      .select("provider_company_id,status,company_type,confidence,reason,checked_at,expires_at")
+      .eq("provider", "apollo").in("provider_company_id", apolloIds),
   ]);
   if (leadsError) console.error("saved lead lookup failed", leadsError);
   if (qualificationError) console.error("qualification lookup failed", qualificationError);
 
-  const savedByApollo = new Map<string, any>();
+  const leadRows = Array.isArray((leadEnvelope as any)?.leads) ? (leadEnvelope as any).leads : [];
   const savedByDomain = new Map<string, any>();
   const savedByName = new Map<string, any>();
-  for (const lead of leadRows || []) {
-    const apolloId = lead.apollo_organization_id || apolloIdFromNotes(lead.notes);
-    const domain = cleanDomain(lead.company_domain || lead.website) || domainFromNotes(lead.notes);
+  for (const lead of leadRows) {
+    const domain = cleanDomain(lead.company_domain || lead.website);
     const name = canonicalName(lead.company_name);
-    if (apolloId) savedByApollo.set(String(apolloId), lead);
     if (domain) savedByDomain.set(domain, lead);
     if (name) savedByName.set(name, lead);
   }
   const qualifications = new Map((qualificationRows || []).map((row: any) => [String(row.provider_company_id), row]));
-  const rows = Array.isArray(payload?.organizations) ? payload.organizations : Array.isArray(payload?.accounts) ? payload.accounts : [];
   const companies = rows.map((org: any) => {
     const id = String(org.id || `${org.name || "company"}-${org.primary_domain || ""}`);
     const domain = cleanDomain(org.primary_domain || org.website_url);
-    const existing = savedByApollo.get(id) || (domain ? savedByDomain.get(domain) : null) || savedByName.get(canonicalName(org.name));
+    const existing = (domain ? savedByDomain.get(domain) : null) || savedByName.get(canonicalName(org.name));
     const qualification: any = qualifications.get(id);
     const qualificationFresh = qualification && new Date(qualification.expires_at).getTime() > Date.now();
     const savedStatus = existing ? existing.deleted_at ? "deleted" : existing.archived_at ? "archived" : "active" : null;

--- a/supabase/functions/lead-crm-qualify-company/deno.json
+++ b/supabase/functions/lead-crm-qualify-company/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/supabase/functions/lead-crm-qualify-company/index.ts
+++ b/supabase/functions/lead-crm-qualify-company/index.ts
@@ -1,0 +1,136 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2.57.4";
+import { Agent, run, setDefaultOpenAIKey, webSearchTool, withTrace } from "npm:@openai/agents@0.16.1";
+import { z } from "npm:zod@4.2.0";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { ...cors, "Content-Type": "application/json" },
+});
+const cleanDomain = (value: unknown) => String(value || "")
+  .replace(/^https?:\/\//i, "").replace(/^www\./i, "").split(/[/?#]/)[0].toLowerCase() || null;
+
+const Evidence = z.object({
+  title: z.string(),
+  url: z.string(),
+  finding: z.string(),
+});
+const Qualification = z.object({
+  status: z.enum(["qualified", "disqualified", "review"]),
+  company_type: z.enum([
+    "freight_broker", "freight_forwarder", "freight_broker_and_forwarder",
+    "other_logistics", "non_target", "unknown",
+  ]),
+  confidence: z.number().min(0).max(1),
+  verified_domain: z.string().nullable(),
+  reason: z.string(),
+  positive_signals: z.array(z.string()),
+  exclusion_signals: z.array(z.string()),
+  evidence: z.array(Evidence),
+});
+
+const instructions = `You are the LIT Lead Qualification Agent. Audit Apollo company candidates before LIT spends credits on contact enrichment or begins outreach.
+
+Search the current web for every company. Prefer the official website, then an independent authoritative source such as FMCSA, FMC, a government registration, or a credible company profile. Confirm that the supplied domain belongs to the same company.
+
+QUALIFY only when current evidence shows the company directly operates as a freight broker that arranges transportation between shippers and carriers, a freight forwarder, an international forwarder, or an NVOCC. A company may also provide 3PL, customs brokerage, warehousing, trucking, or technology services; those extras do not disqualify it if brokerage or forwarding is a real operating service.
+
+DISQUALIFY schools, courses, bootcamps, academies, coaches, media brands, newsletters, podcasts, conferences, communities, influencers, consultants, recruiters, software/data vendors, insurance, factoring/payment companies, compliance/marketing vendors, shippers, importers, manufacturers, carrier-only trucking companies, and warehouse-only operators unless reliable evidence shows they actually broker or forward freight.
+
+A name containing “freight” or “logistics” and an Apollo category are not proof. If sources conflict, the website cannot be verified, or evidence is thin, return REVIEW. Review is not safe for enrichment. Qualified requires at least one strong source and confidence >= 0.75. Keep reasons factual and concise. Never invent licenses or services.`;
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  if (req.method !== "POST") return json({ ok: false, error: "Method not allowed" }, 405);
+
+  const url = Deno.env.get("SUPABASE_URL") || "";
+  const anon = Deno.env.get("SUPABASE_ANON_KEY") || "";
+  const service = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+  const openaiKey = Deno.env.get("Outreach_agent") || Deno.env.get("OPENAI_API_KEY") || "";
+  const authorization = req.headers.get("Authorization") || "";
+  if (!authorization || !url || !anon || !service) return json({ ok: false, error: "Unauthorized" }, 401);
+
+  const caller = createClient(url, anon, { global: { headers: { Authorization: authorization } } });
+  const token = authorization.replace(/^Bearer\s+/i, "");
+  const { data: userData, error: userError } = await caller.auth.getUser(token);
+  if (userError || !userData.user) return json({ ok: false, error: "Unauthorized" }, 401);
+  const { data: access } = await caller.rpc("lit_my_lead_crm_access");
+  const gate = Array.isArray(access) ? access[0] : access;
+  if (!gate?.is_member) return json({ ok: false, error: "Lead CRM membership required" }, 403);
+  if (!openaiKey) return json({ ok: false, error: "Outreach agent is not configured" }, 503);
+
+  let body: Record<string, unknown> = {};
+  try { body = await req.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+  const providerCompanyId = String(body.provider_company_id || "").trim();
+  const companyName = String(body.company_name || "").trim();
+  if (!providerCompanyId || !companyName) return json({ ok: false, error: "Company ID and name are required" }, 400);
+
+  const admin = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
+  const { data: cached } = await admin.from("lit_lead_company_qualifications")
+    .select("status,company_type,confidence,verified_domain,reason,positive_signals,exclusion_signals,evidence,checked_at,expires_at")
+    .eq("provider", "apollo").eq("provider_company_id", providerCompanyId)
+    .gt("expires_at", new Date().toISOString()).maybeSingle();
+  if (cached && body.force !== true) {
+    return json({ ok: true, qualification: { ...cached, safe_to_enrich: cached.status === "qualified" && Number(cached.confidence) >= 0.75 }, cached: true });
+  }
+
+  setDefaultOpenAIKey(openaiKey);
+  const model = Deno.env.get("OUTREACH_AGENT_MODEL") || "gpt-5.6-luna";
+  const agent = new Agent({
+    name: "LIT Lead Qualification Agent",
+    model,
+    instructions,
+    tools: [webSearchTool()],
+    outputType: Qualification,
+  });
+  const input = JSON.stringify({
+    provider: "apollo",
+    provider_company_id: providerCompanyId,
+    company_name: companyName,
+    domain: cleanDomain(body.domain || body.website),
+    website: body.website || null,
+    linkedin_url: body.linkedin_url || null,
+    industry: body.industry || null,
+    location: body.location || null,
+    target_types: ["freight_broker", "freight_forwarder"],
+  });
+
+  try {
+    const result = await withTrace("lit_lead_qualification", async () => run(agent, input));
+    const decision = result.finalOutput;
+    if (!decision) throw new Error("Agent returned no qualification decision");
+    const safeToEnrich = decision.status === "qualified" && decision.confidence >= 0.75;
+    const record = {
+      provider: "apollo",
+      provider_company_id: providerCompanyId,
+      company_name: companyName,
+      domain: cleanDomain(body.domain || body.website),
+      website: body.website ? String(body.website) : null,
+      status: decision.status,
+      company_type: decision.company_type,
+      confidence: decision.confidence,
+      verified_domain: cleanDomain(decision.verified_domain),
+      reason: decision.reason,
+      positive_signals: decision.positive_signals,
+      exclusion_signals: decision.exclusion_signals,
+      evidence: decision.evidence,
+      model,
+      agent_version: "lead-qualification-v1",
+      checked_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30 * 86400_000).toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    const { error: saveError } = await admin.from("lit_lead_company_qualifications")
+      .upsert(record, { onConflict: "provider,provider_company_id" });
+    if (saveError) throw saveError;
+    return json({ ok: true, qualification: { ...record, safe_to_enrich: safeToEnrich }, cached: false });
+  } catch (error) {
+    console.error("lead qualification failed", error);
+    return json({ ok: false, error: error instanceof Error ? error.message : "Qualification failed" }, 502);
+  }
+});

--- a/supabase/migrations/20260817190000_lead_qualification_gate.sql
+++ b/supabase/migrations/20260817190000_lead_qualification_gate.sql
@@ -1,0 +1,143 @@
+alter table public.lit_admin_leads
+  add column if not exists apollo_organization_id text;
+
+update public.lit_admin_leads
+set apollo_organization_id = (regexp_match(notes, 'organization ([A-Za-z0-9_-]+)'))[1]
+where apollo_organization_id is null
+  and notes ~ 'Imported from Apollo.*organization [A-Za-z0-9_-]+';
+
+create unique index if not exists lit_admin_leads_apollo_org_uidx
+  on public.lit_admin_leads (apollo_organization_id)
+  where apollo_organization_id is not null;
+
+create table if not exists public.lit_lead_company_qualifications (
+  id uuid primary key default gen_random_uuid(),
+  provider text not null,
+  provider_company_id text not null,
+  company_name text not null,
+  domain text,
+  website text,
+  status text not null check (status in ('qualified', 'disqualified', 'review')),
+  company_type text not null check (company_type in (
+    'freight_broker', 'freight_forwarder', 'freight_broker_and_forwarder',
+    'other_logistics', 'non_target', 'unknown'
+  )),
+  confidence numeric(5,4) not null check (confidence between 0 and 1),
+  verified_domain text,
+  reason text not null,
+  positive_signals jsonb not null default '[]'::jsonb,
+  exclusion_signals jsonb not null default '[]'::jsonb,
+  evidence jsonb not null default '[]'::jsonb,
+  model text,
+  agent_version text not null default 'lead-qualification-v1',
+  checked_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '30 days'),
+  lead_id uuid references public.lit_admin_leads(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (provider, provider_company_id)
+);
+
+alter table public.lit_lead_company_qualifications enable row level security;
+revoke all on public.lit_lead_company_qualifications from anon, authenticated;
+
+create or replace function public.lit_leadcrm_import_apollo_company(
+  p_apollo_organization_id text,
+  p_company_name text,
+  p_website text default null,
+  p_company_domain text default null,
+  p_logo_url text default null,
+  p_company_city text default null,
+  p_company_state text default null,
+  p_company_country text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_org_id text := nullif(btrim(p_apollo_organization_id), '');
+  v_name text := nullif(btrim(p_company_name), '');
+  v_domain text := nullif(lower(regexp_replace(regexp_replace(coalesce(p_company_domain, p_website, ''), '^\s*https?://', '', 'i'), '^www\.|[/?#].*$', '', 'gi')), '');
+  v_existing public.lit_admin_leads%rowtype;
+  v_stage uuid;
+  v_lead_id uuid;
+  v_qualification public.lit_lead_company_qualifications%rowtype;
+begin
+  if not public.is_lead_crm_member(auth.uid()) then
+    raise exception 'not authorized';
+  end if;
+  if v_org_id is null or v_name is null then
+    return jsonb_build_object('ok', false, 'reason', 'apollo_id_and_company_required');
+  end if;
+
+  select * into v_qualification
+  from public.lit_lead_company_qualifications
+  where provider = 'apollo' and provider_company_id = v_org_id;
+
+  if not found or v_qualification.status <> 'qualified'
+     or v_qualification.confidence < 0.75 or v_qualification.expires_at <= now() then
+    return jsonb_build_object('ok', false, 'reason', 'qualification_required');
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended('apollo:' || v_org_id, 0));
+
+  select * into v_existing
+  from public.lit_admin_leads
+  where apollo_organization_id = v_org_id
+     or (v_domain is not null and lower(regexp_replace(coalesce(company_domain, ''), '^www\.', '')) = v_domain)
+     or (public.lit_canonicalize_name(company_name) = public.lit_canonicalize_name(v_name))
+  order by case when apollo_organization_id = v_org_id then 0 when company_domain is not null then 1 else 2 end,
+           created_at asc
+  limit 1;
+
+  if found then
+    update public.lit_admin_leads
+    set apollo_organization_id = coalesce(apollo_organization_id, v_org_id),
+        company_name = coalesce(company_name, v_name),
+        website = coalesce(website, nullif(btrim(p_website), '')),
+        company_domain = coalesce(company_domain, v_domain),
+        company_logo_url = coalesce(company_logo_url, nullif(btrim(p_logo_url), ''),
+          case when v_domain is not null then 'https://img.logo.dev/' || v_domain || '?size=160' end),
+        company_city = coalesce(company_city, nullif(btrim(p_company_city), '')),
+        company_state = coalesce(company_state, nullif(btrim(p_company_state), '')),
+        company_country = coalesce(company_country, nullif(btrim(p_company_country), '')),
+        updated_at = now()
+    where id = v_existing.id;
+    update public.lit_lead_company_qualifications set lead_id = v_existing.id, updated_at = now() where id = v_qualification.id;
+    return jsonb_build_object(
+      'ok', true, 'lead_id', v_existing.id, 'created', false, 'merged', true,
+      'saved_status', case when v_existing.deleted_at is not null then 'deleted' when v_existing.archived_at is not null then 'archived' else 'active' end
+    );
+  end if;
+
+  select id into v_stage from public.lit_lead_pipeline_stages order by position asc limit 1;
+  insert into public.lit_admin_leads (
+    company_name, website, company_domain, company_logo_url, company_city,
+    company_state, company_country, apollo_organization_id, primary_source,
+    stage_id, notes, status, first_seen_at, last_activity_at
+  ) values (
+    v_name, nullif(btrim(p_website), ''), v_domain,
+    coalesce(nullif(btrim(p_logo_url), ''), case when v_domain is not null then 'https://img.logo.dev/' || v_domain || '?size=160' end),
+    nullif(btrim(p_company_city), ''), nullif(btrim(p_company_state), ''), nullif(btrim(p_company_country), ''),
+    v_org_id, 'apollo', v_stage, 'Imported from Apollo · organization ' || v_org_id,
+    'open', now(), now()
+  ) returning id into v_lead_id;
+
+  insert into public.lit_lead_activity (lead_id, kind, body, actor_user_id, source)
+  values (v_lead_id, 'created', jsonb_build_object(
+    'source', 'apollo', 'company', v_name, 'apollo_organization_id', v_org_id,
+    'qualification_status', v_qualification.status,
+    'qualification_confidence', v_qualification.confidence
+  ), auth.uid(), 'apollo');
+
+  update public.lit_lead_company_qualifications set lead_id = v_lead_id, updated_at = now() where id = v_qualification.id;
+  return jsonb_build_object('ok', true, 'lead_id', v_lead_id, 'created', true, 'merged', false, 'saved_status', 'active');
+exception when unique_violation then
+  select id into v_lead_id from public.lit_admin_leads where apollo_organization_id = v_org_id limit 1;
+  return jsonb_build_object('ok', true, 'lead_id', v_lead_id, 'created', false, 'merged', true, 'saved_status', 'active');
+end;
+$$;
+
+revoke all on function public.lit_leadcrm_import_apollo_company(text, text, text, text, text, text, text, text) from public, anon;
+grant execute on function public.lit_leadcrm_import_apollo_company(text, text, text, text, text, text, text, text) to authenticated;


### PR DESCRIPTION
## What changed
- adds a web-backed OpenAI Agents SDK qualification workflow for freight brokers and freight forwarders
- excludes training, media, consulting, software, factoring/payment, carrier-only, warehouse-only, and other adjacent companies
- requires a qualified decision (confidence >= 0.75) before Apollo import
- gives Apollo companies durable provider IDs and an atomic import RPC
- returns persisted saved state with search results so refreshes and later pages show Saved/Previously saved
- prevents duplicate enrichment and outreach by blocking repeat imports
- adds Lead CRM UI states: Not verified, Verified, Excluded, Needs review, Saved

## Safety
- qualification is fail-closed: review/disqualified cannot be imported
- message sending remains human-approval gated
- saved-state lookup uses the existing caller-authorized Lead CRM RPC
- no broad service-role CRM reads
- qualification function requires JWT and Lead CRM membership

## Verification
- Python agent tests: 4 passed
- Supabase migrations applied
- lead-crm-qualify-company v1 ACTIVE
- lead-crm-find-leads v5 ACTIVE