### PR TITLE
Fix LinkedIn connection diagnostics and Unipile DSN handling

### DIFF
--- a/frontend/src/api/_client.ts
+++ b/frontend/src/api/_client.ts
@@ -27,6 +27,31 @@ export class EdgeFunctionError extends Error {
   }
 }
 
+type SupabaseFunctionError = Error & {
+  context?: Response;
+};
+
+async function normalizeInvokeError(name: string, error: SupabaseFunctionError): Promise<EdgeFunctionError> {
+  const response = error.context;
+  if (response) {
+    let payload: { error?: string; message?: string; code?: string } | null = null;
+    try {
+      payload = await response.clone().json();
+    } catch {
+      payload = null;
+    }
+    const message = payload?.error || payload?.message;
+    if (message) {
+      return new EdgeFunctionError(message, payload?.code || "EDGE_HTTP_ERROR", response.status);
+    }
+  }
+  return new EdgeFunctionError(
+    error.message || `Edge function "${name}" failed`,
+    "INVOKE_FAILED",
+    response?.status,
+  );
+}
+
 /**
  * Call an edge function with the current Supabase user session attached.
  * Throws `EdgeFunctionError` on transport or non-2xx responses; returns the
@@ -42,8 +67,7 @@ export async function invokeEdge<T = unknown>(
 ): Promise<T> {
   const { data, error } = await supabase.functions.invoke(name, { body });
   if (error) {
-    const msg = error.message || `Edge function "${name}" failed`;
-    throw new EdgeFunctionError(msg, "INVOKE_FAILED");
+    throw await normalizeInvokeError(name, error as SupabaseFunctionError);
   }
   // Edge functions in this repo return { ok: true, ... } on success and
   // { ok: false, error: "...", code: "..." } on application-level failure.

--- a/supabase/functions/_shared/unipile.ts
+++ b/supabase/functions/_shared/unipile.ts
@@ -5,7 +5,14 @@ export type UnipileConfig = {
 };
 
 function cleanBaseUrl(value: string): string {
-  return value.trim().replace(/\/+$/, "").replace(/\/api\/v1$/i, "");
+  const trimmed = value.trim();
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const cleaned = withProtocol.replace(/\/+$/, "").replace(/\/api\/v1$/i, "");
+  const parsed = new URL(cleaned);
+  if (parsed.protocol !== "https:" && parsed.hostname !== "localhost") {
+    throw new Error("Unipile DSN must use HTTPS");
+  }
+  return parsed.toString().replace(/\/$/, "");
 }
 
 /**
@@ -44,7 +51,13 @@ export function getUnipileConfig(): UnipileConfig {
   if (!apiKey || !baseUrl) {
     throw new Error("Unipile is not configured: Unipile_API and DSN are required");
   }
-  return { apiKey, baseUrl: cleanBaseUrl(baseUrl), webhookSecret: webhookSecret || undefined };
+  let normalizedBaseUrl = "";
+  try {
+    normalizedBaseUrl = cleanBaseUrl(baseUrl);
+  } catch {
+    throw new Error("Unipile DSN is invalid. Use the API URL shown in the Unipile dashboard, for example https://api1.unipile.com:12345");
+  }
+  return { apiKey, baseUrl: normalizedBaseUrl, webhookSecret: webhookSecret || undefined };
 }
 
 export async function unipileRequest<T = Record<string, unknown>>(

--- a/supabase/functions/unipile-account/index.ts
+++ b/supabase/functions/unipile-account/index.ts
@@ -118,7 +118,14 @@ Deno.serve(async (req) => {
 
     return json({ ok: false, code: "UNKNOWN_ACTION", error: "Unknown action" }, 400);
   } catch (error) {
-    console.error("unipile-account failed", error instanceof Error ? error.message : "unknown");
-    return json({ ok: false, code: "UNIPILE_ACCOUNT_ERROR", error: error instanceof Error ? error.message : "Unipile account operation failed" }, 502);
+    const upstreamStatus = Number((error as { status?: number })?.status || 0);
+    const message = error instanceof Error ? error.message : "Unipile account operation failed";
+    const code = upstreamStatus === 401 || upstreamStatus === 403
+      ? "UNIPILE_CREDENTIALS_REJECTED"
+      : upstreamStatus === 422 || upstreamStatus === 400
+      ? "UNIPILE_REQUEST_REJECTED"
+      : "UNIPILE_ACCOUNT_ERROR";
+    console.error("unipile-account failed", JSON.stringify({ code, upstreamStatus, message }));
+    return json({ ok: false, code, error: message }, upstreamStatus >= 400 && upstreamStatus < 500 ? upstreamStatus : 502);
   }
 });


### PR DESCRIPTION
## Summary
- surface the real Edge Function error body instead of the generic non-2xx message
- normalize Unipile DSNs that are entered without `https://`
- return actionable credential/request error codes from `unipile-account`

## Verification
- `git diff --check` passes
- reviewed against the existing Unipile Hosted Auth request flow
- local Vite build could not run because the scratch dependency tree is incomplete; Vercel CI is the build gate