### PR TITLE
Persist successful Unipile connections before metadata refresh

### DIFF
--- a/supabase/functions/unipile-account-callback/index.ts
+++ b/supabase/functions/unipile-account-callback/index.ts
@@ -44,29 +44,44 @@ Deno.serve(async (req) => {
   if (!session) return json({ ok: false }, 403);
 
   try {
-    const remote = await unipileRequest<Record<string, unknown>>(`/accounts/${encodeURIComponent(remoteAccountId)}`);
     const { data: existing } = await admin.from("lit_unipile_accounts").select("id,org_id")
       .eq("unipile_account_id", remoteAccountId).maybeSingle();
     if (existing && existing.org_id !== session.org_id) {
       throw new Error("This LinkedIn account is already connected to another workspace");
     }
+    const connectedAt = new Date().toISOString();
+    // CREATION_SUCCESS / RECONNECTED is Unipile's authoritative confirmation.
+    // Persist that mapping before making any secondary profile request so a
+    // temporary metadata lookup failure cannot lose a successful connection.
     const { error } = await admin.from("lit_unipile_accounts").upsert({
       org_id: session.org_id,
       owner_user_id: session.user_id,
       unipile_account_id: remoteAccountId,
       provider: "LINKEDIN",
-      display_name: remote.name || remote.username || null,
-      email: remote.email || null,
       status: "OK",
       use_for_campaigns: session.purpose === "campaigns",
       use_for_lead_crm: session.purpose === "lead_crm",
-      connected_at: new Date().toISOString(),
-      last_synced_at: new Date().toISOString(),
-      metadata: remote,
-      updated_at: new Date().toISOString(),
+      connected_at: connectedAt,
+      last_synced_at: connectedAt,
+      metadata: { callback_status: callbackStatus },
+      updated_at: connectedAt,
     }, { onConflict: "unipile_account_id" });
     if (error) throw error;
     await admin.from("lit_unipile_auth_sessions").update({ consumed_at: new Date().toISOString() }).eq("id", session.id);
+
+    // Enrich the card best-effort after the durable mapping exists.
+    try {
+      const remote = await unipileRequest<Record<string, unknown>>(`/accounts/${encodeURIComponent(remoteAccountId)}`);
+      await admin.from("lit_unipile_accounts").update({
+        display_name: typeof remote.name === "string" ? remote.name : typeof remote.username === "string" ? remote.username : null,
+        email: typeof remote.email === "string" ? remote.email : null,
+        metadata: remote,
+        last_synced_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }).eq("unipile_account_id", remoteAccountId);
+    } catch (profileError) {
+      console.warn("Unipile account metadata refresh deferred", profileError instanceof Error ? profileError.message : "unknown");
+    }
     // Webhook setup is best-effort and idempotent at the event-inbox layer.
     // A missing webhook secret never blocks the account connection itself.
     const cfg = getUnipileConfig();
@@ -89,7 +104,8 @@ Deno.serve(async (req) => {
     }
     return json({ ok: true });
   } catch (error) {
-    console.error("unipile callback failed", error instanceof Error ? error.message : "unknown");
-    return json({ ok: false }, 502);
+    const message = error instanceof Error ? error.message : "unknown";
+    console.error("unipile callback failed", JSON.stringify({ sessionId, remoteAccountId, message }));
+    return json({ ok: false, error: message }, 502);
   }
 });


### PR DESCRIPTION
## Root cause
Unipile successfully completed Hosted Auth and POSTed the callback, but LIT returned 502 because it performed a secondary account metadata lookup before saving the confirmed account mapping. The auth session remained unconsumed and Settings correctly found no local account.

## Fix
- treat `CREATION_SUCCESS` / `RECONNECTED` as the authoritative connection result
- persist the org/user/account mapping first
- fetch display metadata only as a best-effort follow-up
- retain an actionable callback error body and structured safe logging

## Verification
- live diagnostics confirmed the failing callback, unconsumed session, and absence of a local account row
- Edge Function `unipile-account-callback` v4 is ACTIVE with JWT verification disabled and custom HMAC/session verification retained
- `git diff --check` passes