### PR TITLE
Complete Unipile account and approval workflow

### DIFF
--- a/frontend/src/api/outreach.ts
+++ b/frontend/src/api/outreach.ts
@@ -172,6 +172,25 @@ export async function refreshUnipileAccount(accountId: string): Promise<UnipileA
   return result.account;
 }
 
+/** Assign a connected sender to Campaigns and/or the internal Lead CRM. */
+export async function updateUnipileAccount(params: {
+  accountId: string;
+  useForCampaigns: boolean;
+  useForLeadCrm: boolean;
+  dailyInviteCap?: number;
+  dailyMessageCap?: number;
+}): Promise<UnipileAccount> {
+  const result = await invokeEdge<{ account: UnipileAccount }>("unipile-account", {
+    action: "update",
+    account_id: params.accountId,
+    use_for_campaigns: params.useForCampaigns,
+    use_for_lead_crm: params.useForLeadCrm,
+    ...(params.dailyInviteCap !== undefined ? { daily_invite_cap: params.dailyInviteCap } : {}),
+    ...(params.dailyMessageCap !== undefined ? { daily_message_cap: params.dailyMessageCap } : {}),
+  });
+  return result.account;
+}
+
 export async function listLinkedInOutreach(params: {
   leadId?: string;
   campaignContactId?: string;

--- a/frontend/src/components/settings/SettingsSections.tsx
+++ b/frontend/src/components/settings/SettingsSections.tsx
@@ -32,7 +32,7 @@ import {
 } from "lucide-react";
 import { PLAN_LIMITS, normalizePlan as normalizePlanCode } from "@/lib/planLimits";
 import { listEmailAccounts, startGmailOAuth, startOutlookOAuth, sendTestEmail, disconnectEmailAccount } from "@/lib/api";
-import { listUnipileAccounts, refreshUnipileAccount, startUnipileLinkedIn, type UnipileAccount } from "@/api/outreach";
+import { listUnipileAccounts, refreshUnipileAccount, startUnipileLinkedIn, updateUnipileAccount, type UnipileAccount } from "@/api/outreach";
 import { resetOnboarding } from "@/lib/onboardingState";
 import { useInboxStatus } from "@/features/outbound/hooks/useInboxStatus";
 import type { LitEmailAccountRow } from "@/types/lit-outbound";
@@ -2193,14 +2193,33 @@ function LinkedInUnipileSection() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function load() {
-    setLoading(true);
-    try { setAccounts(await listUnipileAccounts(orgId || undefined)); }
-    catch (e: any) { setError(e?.message || "Could not load LinkedIn accounts"); }
-    finally { setLoading(false); }
+  async function load(quiet = false): Promise<UnipileAccount[]> {
+    if (!quiet) setLoading(true);
+    try {
+      const rows = await listUnipileAccounts(orgId || undefined);
+      setAccounts(rows);
+      return rows;
+    }
+    catch (e: any) {
+      setError(e?.message || "Could not load LinkedIn accounts");
+      return [];
+    }
+    finally { if (!quiet) setLoading(false); }
   }
 
-  useEffect(() => { void load(); }, [orgId]);
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const returnedFromUnipile = new URLSearchParams(window.location.search).get("unipile") === "connected";
+    let attemptsRemaining = returnedFromUnipile ? 8 : 1;
+    const poll = async () => {
+      const rows = await load(attemptsRemaining < (returnedFromUnipile ? 8 : 1));
+      if (cancelled || rows.some((row) => row.status === "OK") || --attemptsRemaining <= 0) return;
+      timer = setTimeout(() => void poll(), 1500);
+    };
+    void poll();
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
+  }, [orgId]);
 
   async function connect(accountId?: string) {
     setBusy(true); setError(null);
@@ -2222,6 +2241,21 @@ function LinkedInUnipileSection() {
     setBusy(true); setError(null);
     try { await refreshUnipileAccount(accountId); await load(); }
     catch (e: any) { setError(e?.message || "Could not refresh LinkedIn status"); }
+    finally { setBusy(false); }
+  }
+
+  async function updateUsage(account: UnipileAccount, patch: Partial<Pick<UnipileAccount, "use_for_campaigns" | "use_for_lead_crm">>) {
+    setBusy(true); setError(null);
+    try {
+      await updateUnipileAccount({
+        accountId: account.id,
+        useForCampaigns: patch.use_for_campaigns ?? account.use_for_campaigns,
+        useForLeadCrm: patch.use_for_lead_crm ?? account.use_for_lead_crm,
+        dailyInviteCap: account.daily_invite_cap,
+        dailyMessageCap: account.daily_message_cap,
+      });
+      await load(true);
+    } catch (e: any) { setError(e?.message || "Could not update LinkedIn assignment"); }
     finally { setBusy(false); }
   }
 
@@ -2257,8 +2291,21 @@ function LinkedInUnipileSection() {
         )}
       </div>
       {error ? <StatusMsg error={error} /> : null}
+      {connected ? (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(210px,1fr))", gap: 10, margin: "4px 0 12px" }}>
+          {[
+            { key: "campaigns", label: "Customer Campaigns", copy: "Use this sender for approved campaign invitations and messages.", checked: connected.use_for_campaigns },
+            { key: "lead_crm", label: "Internal Lead CRM", copy: "Use this sender for LIT prospecting and one-to-one communication.", checked: connected.use_for_lead_crm },
+          ].map((item) => (
+            <label key={item.key} style={{ display: "flex", gap: 10, padding: 12, border: `1px solid ${item.checked ? "#BFDBFE" : "#E2E8F0"}`, background: item.checked ? "#EFF6FF" : "#F8FAFC", borderRadius: 10, cursor: busy ? "wait" : "pointer" }}>
+              <input type="checkbox" checked={item.checked} disabled={busy} onChange={(e) => void updateUsage(connected, item.key === "campaigns" ? { use_for_campaigns: e.target.checked } : { use_for_lead_crm: e.target.checked })} style={{ accentColor: "#2563EB", marginTop: 2 }} />
+              <span><span style={{ display: "block", fontFamily: "Space Grotesk,sans-serif", fontSize: 12.5, fontWeight: 700, color: "#0F172A" }}>{item.label}</span><span style={{ display: "block", fontFamily: "DM Sans,sans-serif", fontSize: 11.5, lineHeight: 1.4, color: "#64748B", marginTop: 2 }}>{item.copy}</span></span>
+            </label>
+          ))}
+        </div>
+      ) : null}
       <div style={{ fontFamily: "DM Sans,sans-serif", fontSize: 11.5, color: "#94A3B8" }}>
-        Safety defaults: 20 invitations/day and 40 messages/day per account, with provider errors stopping the send instead of retrying aggressively.
+        Safety limits: {connected?.daily_invite_cap ?? 20} invitations/day and {connected?.daily_message_cap ?? 40} messages/day. Provider errors stop delivery instead of retrying aggressively.
       </div>
     </SCard>
   );

--- a/frontend/src/features/outbound/components/LinkedInApprovalQueue.tsx
+++ b/frontend/src/features/outbound/components/LinkedInApprovalQueue.tsx
@@ -52,6 +52,12 @@ export default function LinkedInApprovalQueue({ campaignId }: { campaignId: stri
     }
     return map;
   }, [actions]);
+  const summary = useMemo(() => ({
+    ready: actions.filter((a) => a.status === "pending_approval").length,
+    sent: actions.filter((a) => a.status === "sent" || a.status === "replied").length,
+    missing: recipients.filter((r) => !r.linkedin_url).length,
+    replied: actions.filter((a) => a.status === "replied").length,
+  }), [actions, recipients]);
 
   if (!loading && steps.length === 0) return null;
   async function connect() {
@@ -109,6 +115,16 @@ export default function LinkedInApprovalQueue({ campaignId }: { campaignId: stri
         </div>
       </div>
       {error ? <div className="mt-3 rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">{error}</div> : null}
+      {!loading ? (
+        <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {[
+            ["Awaiting approval", summary.ready, "text-amber-700 bg-amber-50"],
+            ["Sent", summary.sent, "text-blue-700 bg-blue-50"],
+            ["Replies", summary.replied, "text-emerald-700 bg-emerald-50"],
+            ["Missing LinkedIn URL", summary.missing, "text-rose-700 bg-rose-50"],
+          ].map(([label, value, tone]) => <div key={String(label)} className={`rounded-lg px-3 py-2 ${tone}`}><div className="text-lg font-bold">{value}</div><div className="text-[10px] font-semibold uppercase tracking-wide">{label}</div></div>)}
+        </div>
+      ) : null}
       {loading ? <div className="mt-4 flex items-center gap-2 text-xs text-slate-500"><Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading recipients…</div> : recipients.length === 0 ? (
         <div className="mt-4 text-xs text-slate-500">No enrolled campaign recipients yet.</div>
       ) : (

--- a/frontend/src/features/outbound/components/StepInspector.tsx
+++ b/frontend/src/features/outbound/components/StepInspector.tsx
@@ -71,10 +71,10 @@ export function StepInspector({
   const meta = CHANNEL[step.kind];
   const isEmail = step.kind === "email";
   const isWait = step.kind === "wait";
-  const isLinkedInOrCall =
+  const isLinkedIn =
     step.kind === "linkedin_invite" ||
-    step.kind === "linkedin_message" ||
-    step.kind === "call";
+    step.kind === "linkedin_message";
+  const isLinkedInOrCall = isLinkedIn || step.kind === "call";
 
   const insertVariable = (variable: string) => {
     if (isEmail) {
@@ -121,6 +121,8 @@ export function StepInspector({
               ? "Compose · Schedule"
               : isWait
               ? "Wait between steps"
+              : isLinkedIn
+              ? "AI draft · human approval · sent through LinkedIn"
               : "Manual task — sequenced for the rep"}
           </div>
         </div>

--- a/supabase/functions/unipile-account-callback/index.ts
+++ b/supabase/functions/unipile-account-callback/index.ts
@@ -44,7 +44,7 @@ Deno.serve(async (req) => {
   if (!session) return json({ ok: false }, 403);
 
   try {
-    const { data: existing } = await admin.from("lit_unipile_accounts").select("id,org_id")
+    const { data: existing } = await admin.from("lit_unipile_accounts").select("id,org_id,use_for_campaigns,use_for_lead_crm")
       .eq("unipile_account_id", remoteAccountId).maybeSingle();
     if (existing && existing.org_id !== session.org_id) {
       throw new Error("This LinkedIn account is already connected to another workspace");
@@ -59,8 +59,8 @@ Deno.serve(async (req) => {
       unipile_account_id: remoteAccountId,
       provider: "LINKEDIN",
       status: "OK",
-      use_for_campaigns: session.purpose === "campaigns",
-      use_for_lead_crm: session.purpose === "lead_crm",
+      use_for_campaigns: Boolean(existing?.use_for_campaigns) || session.purpose === "campaigns",
+      use_for_lead_crm: Boolean(existing?.use_for_lead_crm) || session.purpose === "lead_crm",
       connected_at: connectedAt,
       last_synced_at: connectedAt,
       metadata: { callback_status: callbackStatus },

--- a/supabase/functions/unipile-account/index.ts
+++ b/supabase/functions/unipile-account/index.ts
@@ -116,6 +116,33 @@ Deno.serve(async (req) => {
       return json({ ok: true, account: updated });
     }
 
+    if (action === "update") {
+      const localId = String(body.account_id || "");
+      const { data: local } = await auth.admin.from("lit_unipile_accounts")
+        .select("id,owner_user_id").eq("id", localId).eq("org_id", orgId).maybeSingle();
+      if (!local) return json({ ok: false, code: "ACCOUNT_NOT_FOUND", error: "LinkedIn account not found" }, 404);
+      if (local.owner_user_id !== auth.user.id && membership?.role !== "owner" && membership?.role !== "admin") {
+        return json({ ok: false, code: "ACCOUNT_FORBIDDEN", error: "Only the account owner or a workspace admin can change sender settings" }, 403);
+      }
+      const wantsLeadCrm = body.use_for_lead_crm === true;
+      if (wantsLeadCrm) {
+        const { data: access } = await auth.userClient.rpc("lit_my_lead_crm_access");
+        const gate = Array.isArray(access) ? access[0] : access;
+        if (!gate?.is_member) return json({ ok: false, code: "LEAD_CRM_REQUIRED", error: "Lead CRM membership required" }, 403);
+      }
+      const inviteCap = Math.max(1, Math.min(40, Number(body.daily_invite_cap || 20)));
+      const messageCap = Math.max(1, Math.min(80, Number(body.daily_message_cap || 40)));
+      const { data: updated, error } = await auth.admin.from("lit_unipile_accounts").update({
+        use_for_campaigns: body.use_for_campaigns === true,
+        use_for_lead_crm: wantsLeadCrm,
+        daily_invite_cap: inviteCap,
+        daily_message_cap: messageCap,
+        updated_at: new Date().toISOString(),
+      }).eq("id", local.id).select().single();
+      if (error) throw error;
+      return json({ ok: true, account: updated });
+    }
+
     return json({ ok: false, code: "UNKNOWN_ACTION", error: "Unknown action" }, 400);
   } catch (error) {
     const upstreamStatus = Number((error as { status?: number })?.status || 0);


### PR DESCRIPTION
## What changed
- lets one connected LinkedIn identity serve customer Campaigns and internal Lead CRM independently
- preserves both assignments across reconnects
- adds Settings assignment controls and visible safety limits
- updates Campaign LinkedIn steps to reflect AI drafting, human approval, and real Unipile delivery
- adds approval-queue operational counts for pending approvals, sent touches, replies, and missing LinkedIn URLs

## Why
The hosted Unipile connection was successful, but the application still presented LinkedIn as a manual task and could not safely reuse the sender across both LIT workflows.

## Safety
No automatic LinkedIn sends were added. Every invitation or message still requires an explicit human approval action.

## Validation
- `git diff --check` passed
- local Vite build was unavailable because this workspace has no installed compiler binary; hosted CI/deployment is the compile authority for this PR